### PR TITLE
Fix cycle check when building module graph.

### DIFF
--- a/demo/renderer/src/main.rs
+++ b/demo/renderer/src/main.rs
@@ -5,5 +5,5 @@ witx_bindgen_rust::import!("../markdown/markdown.witx");
 fn main() {
     let mut buffer = String::new();
     io::stdin().read_to_string(&mut buffer).unwrap();
-    println!("{}", markdown::render(&buffer));
+    print!("{}", markdown::render(&buffer));
 }


### PR DESCRIPTION
This PR allows the graph to form diamond patterns (i.e. a module may have
multiple in-edges) while still checking for a cycle by performing a
topographical sort.