### PR TITLE
Fix redundant edges in the dependency graph.

### DIFF
--- a/crates/wasmlink/src/linker.rs
+++ b/crates/wasmlink/src/linker.rs
@@ -145,7 +145,9 @@ impl Linker {
                     };
 
                     if let Some(predecessor) = predecessor {
-                        graph.add_edge(predecessor, index, ());
+                        if !graph.contains_edge(predecessor, index) {
+                            graph.add_edge(predecessor, index, ());
+                        }
                     };
                 }
                 None => break,


### PR DESCRIPTION
This commit fixes redundant edges in the dependency graph that will occur when
a module imports multiple functions from a dependency.

Without this fix, the linked module is invalid as it will try to create
multiple shim instances, one for each imported function.