### PR TITLE
Update witx-bindgen dependency.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1778,7 +1778,7 @@ dependencies = [
 [[package]]
 name = "witx2"
 version = "0.1.0"
-source = "git+https://github.com/alexcrichton/witx-bindgen?branch=new-api#c526e4fe0f8158fc1e17d73346d02df6f5ed3304"
+source = "git+https://github.com/bytecodealliance/witx-bindgen?branch=main#19c908abbfebe07c6a23dfd0d36ac954a2b32fbf"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/crates/test-modules/modules/Cargo.lock
+++ b/crates/test-modules/modules/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
 [[package]]
 name = "witx-bindgen-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/alexcrichton/witx-bindgen?branch=new-api#dddcd9f6efdd67e9ad7422b9cdd3fbd694fbf01d"
+source = "git+https://github.com/bytecodealliance/witx-bindgen?branch=main#19c908abbfebe07c6a23dfd0d36ac954a2b32fbf"
 dependencies = [
  "anyhow",
  "witx",
@@ -150,7 +150,7 @@ dependencies = [
 [[package]]
 name = "witx-bindgen-gen-rust"
 version = "0.1.0"
-source = "git+https://github.com/alexcrichton/witx-bindgen?branch=new-api#dddcd9f6efdd67e9ad7422b9cdd3fbd694fbf01d"
+source = "git+https://github.com/bytecodealliance/witx-bindgen?branch=main#19c908abbfebe07c6a23dfd0d36ac954a2b32fbf"
 dependencies = [
  "heck",
  "witx-bindgen-gen-core",
@@ -159,7 +159,7 @@ dependencies = [
 [[package]]
 name = "witx-bindgen-gen-rust-wasm"
 version = "0.1.0"
-source = "git+https://github.com/alexcrichton/witx-bindgen?branch=new-api#dddcd9f6efdd67e9ad7422b9cdd3fbd694fbf01d"
+source = "git+https://github.com/bytecodealliance/witx-bindgen?branch=main#19c908abbfebe07c6a23dfd0d36ac954a2b32fbf"
 dependencies = [
  "heck",
  "witx-bindgen-gen-core",
@@ -169,7 +169,7 @@ dependencies = [
 [[package]]
 name = "witx-bindgen-rust"
 version = "0.1.0"
-source = "git+https://github.com/alexcrichton/witx-bindgen?branch=new-api#dddcd9f6efdd67e9ad7422b9cdd3fbd694fbf01d"
+source = "git+https://github.com/bytecodealliance/witx-bindgen?branch=main#19c908abbfebe07c6a23dfd0d36ac954a2b32fbf"
 dependencies = [
  "witx-bindgen-rust-impl",
 ]
@@ -177,7 +177,7 @@ dependencies = [
 [[package]]
 name = "witx-bindgen-rust-impl"
 version = "0.1.0"
-source = "git+https://github.com/alexcrichton/witx-bindgen?branch=new-api#dddcd9f6efdd67e9ad7422b9cdd3fbd694fbf01d"
+source = "git+https://github.com/bytecodealliance/witx-bindgen?branch=main#19c908abbfebe07c6a23dfd0d36ac954a2b32fbf"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -188,7 +188,7 @@ dependencies = [
 [[package]]
 name = "witx2"
 version = "0.1.0"
-source = "git+https://github.com/alexcrichton/witx-bindgen?branch=new-api#dddcd9f6efdd67e9ad7422b9cdd3fbd694fbf01d"
+source = "git+https://github.com/bytecodealliance/witx-bindgen?branch=main#19c908abbfebe07c6a23dfd0d36ac954a2b32fbf"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/crates/test-modules/modules/crates/types-main/Cargo.toml
+++ b/crates/test-modules/modules/crates/types-main/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Peter Huene <peter@huene.dev>"]
 edition = "2018"
 
 [dependencies]
-witx-bindgen-rust = { git = "https://github.com/alexcrichton/witx-bindgen", branch = "new-api" }
+witx-bindgen-rust = { git = "https://github.com/bytecodealliance/witx-bindgen", branch = "main" }

--- a/crates/test-modules/modules/crates/types/Cargo.toml
+++ b/crates/test-modules/modules/crates/types/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-witx-bindgen-rust = { git = "https://github.com/alexcrichton/witx-bindgen", branch = "new-api" }
+witx-bindgen-rust = { git = "https://github.com/bytecodealliance/witx-bindgen", branch = "main" }

--- a/crates/wasmlink/Cargo.toml
+++ b/crates/wasmlink/Cargo.toml
@@ -10,7 +10,7 @@ lazy_static = "1.4.0"
 petgraph = "0.5.1"
 wasm-encoder = "0.4.1"
 wasmparser = "0.78.1"
-witx2 = { git = 'https://github.com/alexcrichton/witx-bindgen', branch = 'new-api' }
+witx2 = { git = "https://github.com/bytecodealliance/witx-bindgen", branch = "main" }
 
 [dev-dependencies]
 wasmprinter = "0.2.26"

--- a/demo/markdown/Cargo.toml
+++ b/demo/markdown/Cargo.toml
@@ -9,6 +9,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pulldown-cmark = "0.8.0"
-witx-bindgen-rust = { git = "https://github.com/alexcrichton/witx-bindgen", branch = "new-api" }
+witx-bindgen-rust = { git = "https://github.com/bytecodealliance/witx-bindgen", branch = "main" }
 
 [workspace]

--- a/demo/renderer/Cargo.toml
+++ b/demo/renderer/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Peter Huene <peter@huene.dev>"]
 edition = "2018"
 
 [dependencies]
-witx-bindgen-rust = { git = "https://github.com/alexcrichton/witx-bindgen", branch = "new-api" }
+witx-bindgen-rust = { git = "https://github.com/bytecodealliance/witx-bindgen", branch = "main" }
 
 [workspace]


### PR DESCRIPTION
This PR updates the witx-bindgen dependency to use the main branch now that
Alex's PR has been merged.