### PR TITLE
Implement support for records and flags.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.25.2",
+ "object",
  "rustc-demangle",
 ]
 
@@ -229,18 +229,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ca3560686e7c9c7ed7e0fe77469f2410ba5d7781b1acaa9adc8d8deea28e3e"
+checksum = "df3f8dd4f920a422c96c53fb6a91cc7932b865fdb60066ae9df7c329342d303f"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf9bf1ffffb6ce3d2e5ebc83549bd2436426c99b31cc550d521364cbe35d276"
+checksum = "ebe85f9a8dbf3c9dfa47ecb89828a7dc17c0b62015b84b5505fd4beba61c542c"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc21936a5a6d07e23849ffe83e5c1f6f50305c074f4b2970ca50c13bf55b821"
+checksum = "12bc4be68da214a56bf9beea4212eb3b9eac16ca9f0b47762f907c4cd4684073"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -266,27 +266,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5b6ffaa87560bebe69a5446449da18090b126037920b0c1c6d5945f72faf6b"
+checksum = "a0c87b69923825cfbc3efde17d929a68cd5b50a4016b2bd0eb8c3933cc5bd8cd"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6b4a8bef04f82e4296782646f733c641d09497df2fabf791323fefaa44c64c"
+checksum = "fe683e7ec6e627facf44b2eab4b263507be4e7ef7ea06eb8cee5283d9b45370e"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b783b351f966fce33e3c03498cb116d16d97a8f9978164a60920bd0d3a99c"
+checksum = "5da80025ca214f0118273f8b94c4790add3b776f0dc97afba6b711757497743b"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c88d3dd48021ff1e37e978a00098524abd3513444ae252c08d37b310b3d2a"
+checksum = "e1c0e8c56f9a63f352a64aaa9c9eef7c205008b03593af7b128a3fbc46eae7e9"
 dependencies = [
  "cranelift-codegen",
  "target-lexicon",
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb6d408e2da77cdbbd65466298d44c86ae71c1785d2ab0d8657753cdb4d9d89"
+checksum = "d10ddafc5f1230d2190eb55018fcdecfcce728c9c2b975f2690ef13691d18eb5"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -715,20 +715,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5b3dd1c072ee7963717671d1ca129f1048fda25edea6b752bfc71ac8854170"
-dependencies = [
- "crc32fast",
- "indexmap",
-]
-
-[[package]]
-name = "object"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bc1d42047cf336f0f939c99e97183cf31551bf0f2865a2ec9c8d91fd4ffb5e"
 dependencies = [
+ "crc32fast",
+ "indexmap",
  "memchr",
 ]
 
@@ -1310,9 +1302,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452fc482d6c9cbd07451e62dfbae1dc381504028406fed3fed54e9dbcae820aa"
+checksum = "54ed414ed6ff3b95653ea07b237cf03c513015d94169aac159755e05a2eaa80f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1333,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a46e511a0783c3b416e6d643cd5f52d0a2749d7d5e6299728bfd4fc80fe3cf4"
+checksum = "6c67b1e49ae6d9bcab37a6f13594aed98d8ab8f5c2117b3bed543d8019688733"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1401,9 +1393,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b310b9d20fcf59385761d1ade7a3ef06aecc380e3d3172035b919eaf7465d9f7"
+checksum = "56828b11cd743a0e9b4207d1c7a8c1a66cb32d14601df10422072802a6aee86c"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1434,9 +1426,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14d500d5c3dc5f5c097158feee123d64b3097f0d836a2a27dff9c761c73c843"
+checksum = "99aca6335ad194d795342137a92afaec9338a2bfcf4caa4c667b5ece16c2bfa9"
 dependencies = [
  "anyhow",
  "base64",
@@ -1455,9 +1447,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c525b39f062eada7db3c1298287b96dcb6e472b9f6b22501300b28d9fa7582f6"
+checksum = "519fa80abe29dc46fc43177cbe391e38c8613c59229c8d1d90d7f226c3c7cede"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1470,14 +1462,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-debug"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d2a763e7a6fc734218e0e463196762a4f409c483063d81e0e85f96343b2e0a"
+checksum = "6ddf6e9bca2f3bc1dd499db2a93d35c735176cff0de7daacdc18c3794f7082e0"
 dependencies = [
  "anyhow",
  "gimli",
  "more-asserts",
- "object 0.24.0",
+ "object",
  "target-lexicon",
  "thiserror",
  "wasmparser",
@@ -1486,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64d0c2d881c31b0d65c1f2695e022d71eb60b9fbdd336aacca28208b58eac90"
+checksum = "0a991635b1cf1d1336fbea7a5f2c0e1dafaa54cb21c632d8414885278fa5d1b1"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -1505,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a089d44cd7e2465d41a53b840a5b4fca1bf6d1ecfebc970eac9592b34ea5f0b3"
+checksum = "7ab6bb95303636d1eba6f7fd2b67c1cd583f73303c73b1a3259b46bb1c2eb299"
 dependencies = [
  "cc",
  "libc",
@@ -1516,9 +1508,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4539ea734422b7c868107e2187d7746d8affbcaa71916d72639f53757ad707"
+checksum = "5f33a0ae79b7c8d050156b22e10fdc49dfb09cc482c251d12bf10e8a833498fb"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -1531,7 +1523,7 @@ dependencies = [
  "gimli",
  "log",
  "more-asserts",
- "object 0.24.0",
+ "object",
  "rayon",
  "region",
  "serde",
@@ -1549,13 +1541,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-obj"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1a8ff85246d091828e2225af521a6208ed28c997bb5c39eb697366dc2e2f2b"
+checksum = "4a879f03d416615f322dcb3aa5cb4cbc47b64b12be6aa235a64ab63a4281d50a"
 dependencies = [
  "anyhow",
  "more-asserts",
- "object 0.24.0",
+ "object",
  "target-lexicon",
  "wasmtime-debug",
  "wasmtime-environ",
@@ -1563,16 +1555,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-profiling"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24364d522dcd67c897c8fffc42e5bdfc57207bbb6d7eeade0da9d4a7d70105b"
+checksum = "171ae3107e8502667b16d336a1dd03e370aa6630a1ce26559aba572ade1031d1"
 dependencies = [
  "anyhow",
  "cfg-if",
  "gimli",
  "lazy_static",
  "libc",
- "object 0.24.0",
+ "object",
  "scroll",
  "serde",
  "target-lexicon",
@@ -1582,9 +1574,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51e57976e8a19a18a18e002c6eb12e5769554204238e47ff155fda1809ef0f7"
+checksum = "0404e10f8b07f940be42aa4b8785b4ab42e96d7167ccc92e35d36eee040309c2"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1607,41 +1599,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9c1b1c56676f6a50ecd2bb5c75b13de8097c63c684daa69555e742bc7c3d87"
+checksum = "39d75f21122ec134c8bfc8840a8742c0d406a65560fb9716b23800bd7cfd6ae5"
 dependencies = [
  "anyhow",
  "wasi-cap-std-sync",
  "wasi-common",
  "wasmtime",
- "wasmtime-wiggle",
  "wiggle",
-]
-
-[[package]]
-name = "wasmtime-wiggle"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1bbcb131716ca1a27300b9ff7d91e1c4e1e273ef27634933d908a9d681a193"
-dependencies = [
- "wasmtime",
- "wasmtime-wiggle-macro",
- "wiggle",
- "wiggle-borrow",
-]
-
-[[package]]
-name = "wasmtime-wiggle-macro"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c548467efc78fbdb9b5e558b2ee7142621ec14a30f6f82ff18c2a36a7f4507e0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wiggle-generate",
- "witx",
 ]
 
 [[package]]
@@ -1673,32 +1639,24 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9665f60d7e1f59c9ee9b09355b800c9d72c14c7b7216115f5a9f9e40fb203d62"
+checksum = "79ca01f1388a549eb3eaa221a072c3cfd3e383618ec6b423e82f2734ee28dd40"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bitflags",
  "thiserror",
  "tracing",
+ "wasmtime",
  "wiggle-macro",
- "witx",
-]
-
-[[package]]
-name = "wiggle-borrow"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1318f02c7d38d591986b978b5da75edabcf1d841929f57d58fc3c4ecebefb8cb"
-dependencies = [
- "wiggle",
 ]
 
 [[package]]
 name = "wiggle-generate"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e5c3eda0ea38a5263bcb350e5cb932f9c9a1978c10dcf9944cad0f6b83d85eb"
+checksum = "544fd41029c33b179656ab1674cd813db7cd473f38f1976ae6e08effb46dd269"
 dependencies = [
  "anyhow",
  "heck",
@@ -1711,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d6175e622c766710a1fa3eb0e06ac05d4f7ef4b91f4e85a54c0f0679b7c07"
+checksum = "9e31ae77a274c9800e6f1342fa4a6dde5e2d72eb9d9b2e0418781be6efc35b58"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/test-modules/Cargo.toml
+++ b/crates/test-modules/Cargo.toml
@@ -9,5 +9,5 @@ anyhow = "1.0.40"
 wasmlink = { path = "../wasmlink" }
 
 [dev-dependencies]
-wasmtime = "0.27.0"
-wasmtime-wasi = "0.27.0"
+wasmtime = "0.28.0"
+wasmtime-wasi = "0.28.0"

--- a/crates/test-modules/modules/Cargo.lock
+++ b/crates/test-modules/modules/Cargo.lock
@@ -13,6 +13,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "flags"
+version = "0.1.0"
+dependencies = [
+ "witx-bindgen-rust",
+]
+
+[[package]]
+name = "flags-main"
+version = "0.1.0"
+dependencies = [
+ "witx-bindgen-rust",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/test-modules/modules/Cargo.lock
+++ b/crates/test-modules/modules/Cargo.lock
@@ -61,6 +61,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "records"
+version = "0.1.0"
+dependencies = [
+ "witx-bindgen-rust",
+]
+
+[[package]]
+name = "records-main"
+version = "0.1.0"
+dependencies = [
+ "witx-bindgen-rust",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/test-modules/modules/Cargo.toml
+++ b/crates/test-modules/modules/Cargo.toml
@@ -4,4 +4,6 @@ members = [
     "crates/types-main",
     "crates/records",
     "crates/records-main",
+    "crates/flags",
+    "crates/flags-main",
 ]

--- a/crates/test-modules/modules/Cargo.toml
+++ b/crates/test-modules/modules/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
 members = [
     "crates/types",
-    "crates/types-main"
+    "crates/types-main",
+    "crates/records",
+    "crates/records-main",
 ]

--- a/crates/test-modules/modules/crates/flags-main/Cargo.toml
+++ b/crates/test-modules/modules/crates/flags-main/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "flags-main"
+version = "0.1.0"
+authors = ["Peter Huene <peter@huene.dev>"]
+edition = "2018"
+
+[dependencies]
+witx-bindgen-rust = { git = "https://github.com/bytecodealliance/witx-bindgen", branch = "main" }

--- a/crates/test-modules/modules/crates/flags-main/build.rs
+++ b/crates/test-modules/modules/crates/flags-main/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=crates/flags/flags.witx");
+}

--- a/crates/test-modules/modules/crates/flags-main/src/main.rs
+++ b/crates/test-modules/modules/crates/flags-main/src/main.rs
@@ -1,0 +1,24 @@
+witx_bindgen_rust::import!("crates/flags/flags.witx");
+
+use flags::*;
+
+fn main() {
+    assert_eq!(roundtrip_flag1(0), 0);
+    assert_eq!(roundtrip_flag1(FLAG1_B0), FLAG1_B0);
+
+    assert_eq!(roundtrip_flag2(0), 0);
+    assert_eq!(roundtrip_flag2(FLAG2_B0), FLAG2_B0);
+    assert_eq!(roundtrip_flag2(FLAG2_B1 | FLAG2_B0), FLAG2_B1 | FLAG2_B0);
+
+    assert_eq!(roundtrip_flag4(0), 0);
+    assert_eq!(roundtrip_flag4(FLAG4_B0), FLAG4_B0);
+    assert_eq!(roundtrip_flag4(FLAG4_B1 | FLAG4_B0), FLAG4_B1 | FLAG4_B0);
+    assert_eq!(
+        roundtrip_flag4(FLAG4_B2 | FLAG4_B1 | FLAG4_B0),
+        FLAG4_B2 | FLAG4_B1 | FLAG4_B0
+    );
+    assert_eq!(
+        roundtrip_flag4(FLAG4_B3 | FLAG4_B2 | FLAG4_B1 | FLAG4_B0),
+        FLAG4_B3 | FLAG4_B2 | FLAG4_B1 | FLAG4_B0
+    );
+}

--- a/crates/test-modules/modules/crates/flags/Cargo.toml
+++ b/crates/test-modules/modules/crates/flags/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "flags"
+version = "0.1.0"
+authors = ["Peter Huene <peter@huene.dev>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+witx-bindgen-rust = { git = "https://github.com/bytecodealliance/witx-bindgen", branch = "main" }

--- a/crates/test-modules/modules/crates/flags/build.rs
+++ b/crates/test-modules/modules/crates/flags/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=crates/flags/flags.witx");
+}

--- a/crates/test-modules/modules/crates/flags/flags.witx
+++ b/crates/test-modules/modules/crates/flags/flags.witx
@@ -1,0 +1,46 @@
+flags flag1 {
+  b0,
+}
+
+flags flag2 {
+  b0, b1,
+}
+
+flags flag4 {
+  b0, b1, b2, b3,
+}
+
+flags flag8 {
+  b0, b1, b2, b3, b4, b5, b6, b7,
+}
+
+flags flag16 {
+  b0, b1, b2, b3, b4, b5, b6, b7,
+  b8, b9, b10, b11, b12, b13, b14, b15,
+}
+
+flags flag32 {
+  b0, b1, b2, b3, b4, b5, b6, b7,
+  b8, b9, b10, b11, b12, b13, b14, b15,
+  b16, b17, b18, b19, b20, b21, b22, b23,
+  b24, b25, b26, b27, b28, b29, b30, b31,
+}
+
+flags flag64 {
+  b0, b1, b2, b3, b4, b5, b6, b7,
+  b8, b9, b10, b11, b12, b13, b14, b15,
+  b16, b17, b18, b19, b20, b21, b22, b23,
+  b24, b25, b26, b27, b28, b29, b30, b31,
+  b32, b33, b34, b35, b36, b37, b38, b39,
+  b40, b41, b42, b43, b44, b45, b46, b47,
+  b48, b49, b50, b51, b52, b53, b54, b55,
+  b56, b57, b58, b59, b60, b61, b62, b63,
+}
+
+roundtrip_flag1: function(x: flag1) -> flag1
+roundtrip_flag2: function(x: flag2) -> flag2
+roundtrip_flag4: function(x: flag4) -> flag4
+roundtrip_flag8: function(x: flag8) -> flag8
+roundtrip_flag16: function(x: flag16) -> flag16
+roundtrip_flag32: function(x: flag32) -> flag32
+roundtrip_flag64: function(x: flag64) -> flag64

--- a/crates/test-modules/modules/crates/flags/src/lib.rs
+++ b/crates/test-modules/modules/crates/flags/src/lib.rs
@@ -1,0 +1,34 @@
+witx_bindgen_rust::export!("crates/flags/flags.witx");
+
+struct Component;
+
+use flags::*;
+
+impl Flags for Component {
+    fn roundtrip_flag1(&self, x: Flag1) -> Flag1 {
+        x
+    }
+    fn roundtrip_flag2(&self, x: Flag2) -> Flag2 {
+        x
+    }
+    fn roundtrip_flag4(&self, x: Flag4) -> Flag4 {
+        x
+    }
+    fn roundtrip_flag8(&self, x: Flag8) -> Flag8 {
+        x
+    }
+    fn roundtrip_flag16(&self, x: Flag16) -> Flag16 {
+        x
+    }
+    fn roundtrip_flag32(&self, x: Flag32) -> Flag32 {
+        x
+    }
+    fn roundtrip_flag64(&self, x: Flag64) -> Flag64 {
+        x
+    }
+}
+
+fn flags() -> &'static impl Flags {
+    static INSTANCE: Component = Component;
+    &INSTANCE
+}

--- a/crates/test-modules/modules/crates/records-main/Cargo.toml
+++ b/crates/test-modules/modules/crates/records-main/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "records-main"
+version = "0.1.0"
+authors = ["Peter Huene <peter@huene.dev>"]
+edition = "2018"
+
+[dependencies]
+witx-bindgen-rust = { git = "https://github.com/bytecodealliance/witx-bindgen", branch = "main" }

--- a/crates/test-modules/modules/crates/records-main/build.rs
+++ b/crates/test-modules/modules/crates/records-main/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=crates/records/records.witx");
+}

--- a/crates/test-modules/modules/crates/records-main/src/main.rs
+++ b/crates/test-modules/modules/crates/records-main/src/main.rs
@@ -1,32 +1,41 @@
 witx_bindgen_rust::import!("crates/records/records.witx");
 
-use records::{AggregatesParam, Empty, Scalars};
+use records::*;
 
 fn main() {
-    records::tuple_arg(('a', 0));
+    tuple_arg(('a', 0));
 
-    assert_eq!(records::tuple_result(), ('b', 1));
+    assert_eq!(tuple_result(), ('b', 1));
 
-    records::empty_arg(Empty {});
+    empty_arg(Empty {});
 
-    records::empty_result();
+    empty_result();
 
-    records::scalar_arg(Scalars { a: 1, b: 2 });
+    scalar_arg(Scalars { a: 1, b: 2 });
 
-    let x = records::scalar_result();
+    let x = scalar_result();
     assert_eq!(x.a, 3);
     assert_eq!(x.b, 4);
 
-    records::aggregate_arg(AggregatesParam {
+    flags_arg(REALLY_FLAGS_B | REALLY_FLAGS_E | REALLY_FLAGS_F | REALLY_FLAGS_G | REALLY_FLAGS_I);
+    let x = flags_result();
+    assert_eq!(
+        x,
+        REALLY_FLAGS_A | REALLY_FLAGS_C | REALLY_FLAGS_D | REALLY_FLAGS_H
+    );
+
+    aggregate_arg(AggregatesParam {
         a: Scalars { a: 10, b: 100 },
         b: 7,
         c: Empty {},
         d: "hello world!",
+        e: REALLY_FLAGS_F,
     });
 
-    let x = records::aggregate_result();
+    let x = aggregate_result();
     assert_eq!(x.a.a, 11);
     assert_eq!(x.a.b, 101);
     assert_eq!(x.b, 8);
     assert_eq!(x.d, "I love Wasm!");
+    assert_eq!(x.e, REALLY_FLAGS_G);
 }

--- a/crates/test-modules/modules/crates/records-main/src/main.rs
+++ b/crates/test-modules/modules/crates/records-main/src/main.rs
@@ -1,0 +1,32 @@
+witx_bindgen_rust::import!("crates/records/records.witx");
+
+use records::{AggregatesParam, Empty, Scalars};
+
+fn main() {
+    records::tuple_arg(('a', 0));
+
+    assert_eq!(records::tuple_result(), ('b', 1));
+
+    records::empty_arg(Empty {});
+
+    records::empty_result();
+
+    records::scalar_arg(Scalars { a: 1, b: 2 });
+
+    let x = records::scalar_result();
+    assert_eq!(x.a, 3);
+    assert_eq!(x.b, 4);
+
+    records::aggregate_arg(AggregatesParam {
+        a: Scalars { a: 10, b: 100 },
+        b: 7,
+        c: Empty {},
+        d: "hello world!",
+    });
+
+    let x = records::aggregate_result();
+    assert_eq!(x.a.a, 11);
+    assert_eq!(x.a.b, 101);
+    assert_eq!(x.b, 8);
+    assert_eq!(x.d, "I love Wasm!");
+}

--- a/crates/test-modules/modules/crates/records/Cargo.toml
+++ b/crates/test-modules/modules/crates/records/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "records"
+version = "0.1.0"
+authors = ["Peter Huene <peter@huene.dev>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+witx-bindgen-rust = { git = "https://github.com/bytecodealliance/witx-bindgen", branch = "main" }

--- a/crates/test-modules/modules/crates/records/build.rs
+++ b/crates/test-modules/modules/crates/records/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=crates/records/records.witx");
+}

--- a/crates/test-modules/modules/crates/records/records.witx
+++ b/crates/test-modules/modules/crates/records/records.witx
@@ -1,0 +1,25 @@
+tuple_arg: function(x: tuple<char, u32>)
+tuple_result: function() -> tuple<char, u32>
+
+record empty {}
+
+empty_arg: function(x: empty)
+empty_result: function() -> empty
+
+record scalars {
+    a: u32,
+    b: u32,
+}
+
+scalar_arg: function(x: scalars)
+scalar_result: function() -> scalars
+
+record aggregates {
+    a: scalars,
+    b: u32,
+    c: empty,
+    d: string,
+}
+
+aggregate_arg: function(x: aggregates)
+aggregate_result: function() -> aggregates

--- a/crates/test-modules/modules/crates/records/records.witx
+++ b/crates/test-modules/modules/crates/records/records.witx
@@ -14,11 +14,27 @@ record scalars {
 scalar_arg: function(x: scalars)
 scalar_result: function() -> scalars
 
+record really_flags {
+    a: bool,
+    b: bool,
+    c: bool,
+    d: bool,
+    e: bool,
+    f: bool,
+    g: bool,
+    h: bool,
+    i: bool,
+}
+
+flags_arg: function(x: really_flags)
+flags_result: function() -> really_flags
+
 record aggregates {
     a: scalars,
     b: u32,
     c: empty,
     d: string,
+    e: really_flags,
 }
 
 aggregate_arg: function(x: aggregates)

--- a/crates/test-modules/modules/crates/records/src/lib.rs
+++ b/crates/test-modules/modules/crates/records/src/lib.rs
@@ -1,0 +1,45 @@
+witx_bindgen_rust::export!("crates/records/records.witx");
+
+use records::{Aggregates, Empty, Scalars};
+
+struct Component;
+
+impl records::Records for Component {
+    fn tuple_arg(&self, x: (char, u32)) {
+        assert_eq!(x.0, 'a');
+        assert_eq!(x.1, 0);
+    }
+    fn tuple_result(&self) -> (char, u32) {
+        ('b', 1)
+    }
+    fn empty_arg(&self, _: Empty) {}
+    fn empty_result(&self) -> Empty {
+        Empty {}
+    }
+    fn scalar_arg(&self, x: Scalars) {
+        assert_eq!(x.a, 1);
+        assert_eq!(x.b, 2);
+    }
+    fn scalar_result(&self) -> Scalars {
+        Scalars { a: 3, b: 4 }
+    }
+    fn aggregate_arg(&self, x: Aggregates) {
+        assert_eq!(x.a.a, 10);
+        assert_eq!(x.a.b, 100);
+        assert_eq!(x.b, 7);
+        assert_eq!(x.d, "hello world!");
+    }
+    fn aggregate_result(&self) -> Aggregates {
+        Aggregates {
+            a: Scalars { a: 11, b: 101 },
+            b: 8,
+            c: Empty {},
+            d: "I love Wasm!".to_string(),
+        }
+    }
+}
+
+fn records() -> &'static impl records::Records {
+    static INSTANCE: Component = Component;
+    &INSTANCE
+}

--- a/crates/test-modules/modules/crates/records/src/lib.rs
+++ b/crates/test-modules/modules/crates/records/src/lib.rs
@@ -1,10 +1,10 @@
 witx_bindgen_rust::export!("crates/records/records.witx");
 
-use records::{Aggregates, Empty, Scalars};
+use records::*;
 
 struct Component;
 
-impl records::Records for Component {
+impl Records for Component {
     fn tuple_arg(&self, x: (char, u32)) {
         assert_eq!(x.0, 'a');
         assert_eq!(x.1, 0);
@@ -23,11 +23,21 @@ impl records::Records for Component {
     fn scalar_result(&self) -> Scalars {
         Scalars { a: 3, b: 4 }
     }
+    fn flags_arg(&self, x: ReallyFlags) {
+        assert_eq!(
+            x,
+            REALLY_FLAGS_B | REALLY_FLAGS_E | REALLY_FLAGS_F | REALLY_FLAGS_G | REALLY_FLAGS_I
+        );
+    }
+    fn flags_result(&self) -> ReallyFlags {
+        REALLY_FLAGS_A | REALLY_FLAGS_C | REALLY_FLAGS_D | REALLY_FLAGS_H
+    }
     fn aggregate_arg(&self, x: Aggregates) {
         assert_eq!(x.a.a, 10);
         assert_eq!(x.a.b, 100);
         assert_eq!(x.b, 7);
         assert_eq!(x.d, "hello world!");
+        assert_eq!(x.e, REALLY_FLAGS_F);
     }
     fn aggregate_result(&self) -> Aggregates {
         Aggregates {
@@ -35,11 +45,12 @@ impl records::Records for Component {
             b: 8,
             c: Empty {},
             d: "I love Wasm!".to_string(),
+            e: REALLY_FLAGS_G,
         }
     }
 }
 
-fn records() -> &'static impl records::Records {
+fn records() -> &'static impl Records {
     static INSTANCE: Component = Component;
     &INSTANCE
 }

--- a/crates/test-modules/modules/crates/types-main/build.rs
+++ b/crates/test-modules/modules/crates/types-main/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=crates/types/types.witx");
+}

--- a/crates/test-modules/modules/crates/types-main/src/main.rs
+++ b/crates/test-modules/modules/crates/types-main/src/main.rs
@@ -2,7 +2,10 @@ witx_bindgen_rust::import!("crates/types/types.witx");
 
 fn main() {
     types::a();
-    assert_eq!(types::b(1, -2, 3, 4, 5, -6, 7, 8), (1, -2, 3, 4, 5, -6, 7, 8));
+    assert_eq!(
+        types::b(1, -2, 3, 4, 5, -6, 7, 8),
+        (1, -2, 3, 4, 5, -6, 7, 8)
+    );
     assert_eq!(types::c(1.7, 2.6), (1.7, 2.6));
     assert_eq!(types::d("this is a string"), "this is a string");
     assert_eq!(types::e(), "hello world!");

--- a/crates/test-modules/modules/crates/types/build.rs
+++ b/crates/test-modules/modules/crates/types/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=crates/types/types.witx");
+}

--- a/crates/test-modules/src/lib.rs
+++ b/crates/test-modules/src/lib.rs
@@ -80,15 +80,16 @@ mod tests {
 
     #[test]
     fn basic_types() -> Result<()> {
-        run(&link("types-main", &["types"])?)?;
-
-        Ok(())
+        run(&link("types-main", &["types"])?)
     }
 
     #[test]
     fn records() -> Result<()> {
-        run(&link("records-main", &["records"])?)?;
+        run(&link("records-main", &["records"])?)
+    }
 
-        Ok(())
+    #[test]
+    fn flags() -> Result<()> {
+        run(&link("flags-main", &["flags"])?)
     }
 }

--- a/crates/test-modules/src/lib.rs
+++ b/crates/test-modules/src/lib.rs
@@ -7,7 +7,7 @@ mod tests {
         path::{Path, PathBuf},
     };
     use wasmlink::{Linker, Module, Profile};
-    use wasmtime_wasi::{Wasi, WasiCtxBuilder};
+    use wasmtime_wasi::WasiCtxBuilder;
 
     fn module_path(name: &str) -> PathBuf {
         Path::new("modules/target/wasm32-wasi")
@@ -63,19 +63,17 @@ mod tests {
         config.wasm_module_linking(true);
         config.wasm_multi_memory(true);
 
-        Wasi::add_to_config(&mut config);
-
         let engine = Engine::new(&config)?;
+        let mut linker = wasmtime::Linker::new(&engine);
+        wasmtime_wasi::add_to_linker(&mut linker, |s| s)?;
+
         let module = Module::new(&engine, module)?;
-        let store = Store::new(&engine);
+        let mut store = Store::new(&engine, WasiCtxBuilder::new().inherit_stdout().build());
 
-        assert!(Wasi::set_context(&store, WasiCtxBuilder::new().build()).is_ok());
+        let instance = linker.instantiate(&mut store, &module)?;
+        let start = instance.get_typed_func::<(), (), _>(&mut store, "_start")?;
 
-        let linker = wasmtime::Linker::new(&store);
-        let instance = linker.instantiate(&module)?;
-        let start = instance.get_typed_func::<(), ()>("_start")?;
-
-        start.call(())?;
+        start.call(store, ())?;
 
         Ok(())
     }
@@ -83,6 +81,13 @@ mod tests {
     #[test]
     fn basic_types() -> Result<()> {
         run(&link("types-main", &["types"])?)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn records() -> Result<()> {
+        run(&link("records-main", &["records"])?)?;
 
         Ok(())
     }

--- a/crates/wasmlink/src/adapted/generator.rs
+++ b/crates/wasmlink/src/adapted/generator.rs
@@ -19,6 +19,52 @@ fn to_val_type(ty: &WasmType) -> wasm_encoder::ValType {
     }
 }
 
+fn param_to_operand(interface: &Interface, index: u32, ty: &Type) -> (u32, Operand) {
+    match ty {
+        Type::Id(id) => match &interface.types.get(*id).unwrap().kind {
+            TypeDefKind::Record(r) => {
+                let (count, fields) = match r.kind {
+                    RecordKind::Flags(_) => match interface.flags_repr(r) {
+                        Some(_) => (1, vec![Box::new(Operand::Local(index))]),
+                        None => {
+                            let mut fields = Vec::with_capacity(r.num_i32s());
+                            for i in 0..fields.len() as u32 {
+                                fields.push(Box::new(Operand::Local(index + i)));
+                            }
+                            (fields.len() as u32, fields)
+                        }
+                    },
+                    RecordKind::Tuple | RecordKind::Other => {
+                        let mut fields = Vec::new();
+                        let mut count = 0;
+                        for f in &r.fields {
+                            let (local, operand) =
+                                param_to_operand(interface, index + count, &f.ty);
+                            fields.push(Box::new(operand));
+                            count += local;
+                        }
+                        (count, fields)
+                    }
+                };
+                (count, Operand::Record { fields })
+            }
+            TypeDefKind::Variant(_) => todo!(),
+            TypeDefKind::List(_) => (
+                2,
+                Operand::List {
+                    addr: index,
+                    len: index + 1,
+                },
+            ),
+            TypeDefKind::Pointer(_) | TypeDefKind::ConstPointer(_) => (1, Operand::Local(index)),
+            TypeDefKind::PushBuffer(_) => todo!(),
+            TypeDefKind::PullBuffer(_) => todo!(),
+            TypeDefKind::Type(t) => param_to_operand(interface, index, t),
+        },
+        _ => (1, Operand::Local(index)),
+    }
+}
+
 enum LoadType {
     I32,
     I32_8U,
@@ -50,6 +96,78 @@ impl From<&WasmType> for StoreType {
     }
 }
 
+#[derive(Debug, Clone)]
+pub enum Operand {
+    Local(u32),
+    I32Const(i32),
+    Pointer { addr: u32, memory: u32 },
+    List { addr: u32, len: u32 },
+    Record { fields: Vec<Box<Operand>> },
+}
+
+impl Operand {
+    fn local(&self) -> Option<u32> {
+        match self {
+            Operand::Local(i) => Some(*i),
+            _ => None,
+        }
+    }
+
+    fn load(&self, instructions: &mut Vec<wasm_encoder::Instruction>) {
+        match self {
+            Self::Local(i) | Self::Pointer { addr: i, .. } => {
+                instructions.push(wasm_encoder::Instruction::LocalGet(*i));
+            }
+            Self::I32Const(i) => {
+                instructions.push(wasm_encoder::Instruction::I32Const(*i));
+            }
+            Self::List { .. } => panic!("list operands must be split"),
+            Self::Record { fields } => {
+                for field in fields {
+                    field.load(instructions);
+                }
+            }
+        }
+    }
+
+    fn store<'a>(
+        &self,
+        generator: &mut CodeGenerator<'_>,
+        addr: &Operand,
+        types: &mut impl Iterator<Item = &'a WasmType>,
+        offset: &mut u32,
+        alignment: u32,
+    ) {
+        match self {
+            Self::Local(i) | Self::Pointer { addr: i, .. } => {
+                let ty = types.next().expect("incorrect number of types");
+                assert!(*ty == generator.local_type(*i));
+
+                generator.emit_store(addr, *offset, self, ty.into());
+                *offset += alignment;
+            }
+            Self::List { .. } => {
+                let (list, len) = self.split_list();
+                list.store(generator, addr, types, offset, alignment);
+                len.store(generator, addr, types, offset, alignment);
+            }
+            Self::Record { fields } => {
+                for field in fields {
+                    field.store(generator, addr, types, offset, alignment);
+                }
+            }
+            _ => panic!("expected a local, list, or record"),
+        }
+    }
+
+    fn split_list(&self) -> (Self, Self) {
+        match self {
+            Self::List { addr, len } => (Self::Local(*addr), Self::Local(*len)),
+            _ => panic!("expected a list operand to split"),
+        }
+    }
+}
+
 pub struct CodeGenerator<'a> {
     params: Vec<Operand>,
     signature: WasmSignature,
@@ -60,39 +178,6 @@ pub struct CodeGenerator<'a> {
     parent_realloc_index: u32,
     realloc_index: u32,
     sizes: SizeAlign,
-}
-
-fn arg_to_operand(interface: &Interface, index: u32, ty: &Type) -> (u32, Operand) {
-    match ty {
-        Type::Id(id) => match &interface.types.get(*id).unwrap().kind {
-            TypeDefKind::Record(r) => match r.kind {
-                RecordKind::Flags(f) => todo!(),
-                RecordKind::Tuple | RecordKind::Other => {
-                    let mut offset = 0;
-                    let mut fields = Vec::new();
-                    for f in &r.fields {
-                        let (count, operand) = arg_to_operand(interface, index + offset, &f.ty);
-                        fields.push(Box::new(operand));
-                        offset += count;
-                    }
-                    (offset, Operand::Record { fields })
-                }
-            },
-            TypeDefKind::Variant(_) => todo!(),
-            TypeDefKind::List(_) => (
-                2,
-                Operand::List {
-                    addr: index,
-                    len: index + 1,
-                },
-            ),
-            TypeDefKind::Pointer(_) | TypeDefKind::ConstPointer(_) => (1, Operand::Local(index)),
-            TypeDefKind::PushBuffer(_) => todo!(),
-            TypeDefKind::PullBuffer(_) => todo!(),
-            TypeDefKind::Type(t) => arg_to_operand(interface, index, t),
-        },
-        _ => (1, Operand::Local(index)),
-    }
 }
 
 impl<'a> CodeGenerator<'a> {
@@ -110,7 +195,7 @@ impl<'a> CodeGenerator<'a> {
             .params
             .iter()
             .map(|(_, ty)| {
-                let (count, operand) = arg_to_operand(interface, locals_start_index, ty);
+                let (count, operand) = param_to_operand(interface, locals_start_index, ty);
                 locals_start_index += count;
                 operand
             })
@@ -246,78 +331,6 @@ impl<'a> CodeGenerator<'a> {
                 self.instructions.push(inst);
             }
             _ => panic!("expected a pointer for first operand"),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum Operand {
-    Local(u32),
-    I32Const(i32),
-    Pointer { addr: u32, memory: u32 },
-    List { addr: u32, len: u32 },
-    Record { fields: Vec<Box<Operand>> },
-}
-
-impl Operand {
-    fn local(&self) -> Option<u32> {
-        match self {
-            Operand::Local(i) => Some(*i),
-            _ => None,
-        }
-    }
-
-    fn load(&self, instructions: &mut Vec<wasm_encoder::Instruction>) {
-        match self {
-            Self::Local(i) | Self::Pointer { addr: i, .. } => {
-                instructions.push(wasm_encoder::Instruction::LocalGet(*i));
-            }
-            Self::I32Const(i) => {
-                instructions.push(wasm_encoder::Instruction::I32Const(*i));
-            }
-            Self::List { .. } => panic!("list operands must be split"),
-            Self::Record { fields } => {
-                for field in fields {
-                    field.load(instructions);
-                }
-            }
-        }
-    }
-
-    fn store<'a>(
-        &self,
-        generator: &mut CodeGenerator<'_>,
-        addr: &Operand,
-        types: &mut impl Iterator<Item = &'a WasmType>,
-        offset: &mut u32,
-        alignment: u32,
-    ) {
-        match self {
-            Self::Local(i) | Self::Pointer { addr: i, .. } => {
-                let ty = types.next().expect("incorrect number of types");
-                assert!(*ty == generator.local_type(*i));
-
-                generator.emit_store(addr, *offset, self, ty.into());
-                *offset += alignment;
-            }
-            Self::List { .. } => {
-                let (list, len) = self.split_list();
-                list.store(generator, addr, types, offset, alignment);
-                len.store(generator, addr, types, offset, alignment);
-            }
-            Self::Record { fields } => {
-                for field in fields {
-                    field.store(generator, addr, types, offset, alignment);
-                }
-            }
-            _ => panic!("expected a local, list, or record"),
-        }
-    }
-
-    fn split_list(&self) -> (Self, Self) {
-        match self {
-            Self::List { addr, len } => (Self::Local(*addr), Self::Local(*len)),
-            _ => panic!("expected a list operand to split"),
         }
     }
 }
@@ -554,7 +567,9 @@ impl<'a> Bindgen for CodeGenerator<'a> {
             Instruction::BufferLowerHandle { .. } => todo!(),
             Instruction::BufferLiftPtrLen { .. } => todo!(),
             Instruction::BufferLiftHandle { .. } => todo!(),
-            Instruction::RecordLower { .. } => match operands.swap_remove(0) {
+            Instruction::RecordLower { .. }
+            | Instruction::FlagsLower { .. }
+            | Instruction::FlagsLower64 { .. } => match operands.swap_remove(0) {
                 Operand::Record { fields } => {
                     for f in fields {
                         results.push(*f);
@@ -562,15 +577,13 @@ impl<'a> Bindgen for CodeGenerator<'a> {
                 }
                 _ => panic!("expected a record operand"),
             },
-            Instruction::RecordLift { .. } => {
+            Instruction::RecordLift { .. }
+            | Instruction::FlagsLift { .. }
+            | Instruction::FlagsLift64 { .. } => {
                 results.push(Operand::Record {
                     fields: operands.into_iter().map(|o| Box::new(o.clone())).collect(),
                 });
             }
-            Instruction::FlagsLower { .. } => todo!(),
-            Instruction::FlagsLower64 { .. } => todo!(),
-            Instruction::FlagsLift { .. } => todo!(),
-            Instruction::FlagsLift64 { .. } => todo!(),
             Instruction::VariantPayload => todo!(),
             Instruction::VariantLower { .. } => todo!(),
             Instruction::VariantLift { .. } => todo!(),


### PR DESCRIPTION
This PR implements support for linking with interfaces that pass and return
record types and flag types.

New tests were added that were modeled after the tests found in the witx-bindgen repo.