### PR TITLE
Implement support for lists.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,9 +608,9 @@ checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "itertools"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
 ]
@@ -1354,6 +1354,7 @@ name = "wasmlink"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "itertools",
  "lazy_static",
  "petgraph",
  "wasm-encoder",

--- a/crates/test-modules/modules/Cargo.lock
+++ b/crates/test-modules/modules/Cargo.lock
@@ -48,6 +48,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
+name = "lists"
+version = "0.1.0"
+dependencies = [
+ "witx-bindgen-rust",
+]
+
+[[package]]
+name = "lists-main"
+version = "0.1.0"
+dependencies = [
+ "witx-bindgen-rust",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/test-modules/modules/Cargo.toml
+++ b/crates/test-modules/modules/Cargo.toml
@@ -6,4 +6,6 @@ members = [
     "crates/records-main",
     "crates/flags",
     "crates/flags-main",
+    "crates/lists",
+    "crates/lists-main",
 ]

--- a/crates/test-modules/modules/crates/lists-main/Cargo.toml
+++ b/crates/test-modules/modules/crates/lists-main/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "lists-main"
+version = "0.1.0"
+authors = ["Peter Huene <peter@huene.dev>"]
+edition = "2018"
+
+[dependencies]
+witx-bindgen-rust = { git = "https://github.com/bytecodealliance/witx-bindgen", branch = "main" }

--- a/crates/test-modules/modules/crates/lists-main/build.rs
+++ b/crates/test-modules/modules/crates/lists-main/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=crates/lists/lists.witx");
+}

--- a/crates/test-modules/modules/crates/lists-main/src/main.rs
+++ b/crates/test-modules/modules/crates/lists-main/src/main.rs
@@ -1,0 +1,118 @@
+witx_bindgen_rust::import!("crates/lists/lists.witx");
+
+use lists::*;
+
+fn main() {
+    list_u8_param(&[5, 4, 3, 2, 1]);
+    list_u16_param(&[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+    list_u32_param(&[15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+    list_u64_param(&[
+        20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
+    ]);
+    list_s8_param(&[-1, 2, -3, 4, -5]);
+    list_s16_param(&[-1, 2, -3, 4, -5, 6, -7, 8, -9, 10]);
+    list_s32_param(&[-1, 2, -3, 4, -5, 6, -7, 8, -9, 10, -11, 12, -13, 14, -15]);
+    list_s64_param(&[
+        -1, 2, -3, 4, -5, 6, -7, 8, -9, 10, -11, 12, -13, 14, -15, 16, -17, 18, -19, 20,
+    ]);
+
+    assert_eq!(list_u8_ret(), &[5, 4, 3, 2, 1]);
+    assert_eq!(list_u16_ret(), &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+    assert_eq!(
+        list_u32_ret(),
+        &[15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+    );
+    assert_eq!(
+        list_u64_ret(),
+        &[20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+    );
+    assert_eq!(list_s8_ret(), &[-1, 2, -3, 4, -5]);
+    assert_eq!(list_s16_ret(), &[-1, 2, -3, 4, -5, 6, -7, 8, -9, 10]);
+    assert_eq!(
+        list_s32_ret(),
+        &[-1, 2, -3, 4, -5, 6, -7, 8, -9, 10, -11, 12, -13, 14, -15]
+    );
+    assert_eq!(
+        list_s64_ret(),
+        &[-1, 2, -3, 4, -5, 6, -7, 8, -9, 10, -11, 12, -13, 14, -15, 16, -17, 18, -19, 20]
+    );
+
+    assert_eq!(
+        tuple_list(&[
+            (1, -2),
+            (3, 4),
+            (5, -6),
+            (7, 8),
+            (9, -10),
+            (11, 12),
+            (13, -14)
+        ]),
+        &[
+            (-1, 2),
+            (3, 4),
+            (-5, 6),
+            (7, 8),
+            (-9, 10),
+            (11, 12),
+            (-13, 14)
+        ]
+    );
+
+    let x = tuple_string_list(&[(0, "hello"), (1, "world")]);
+    assert_eq!(x.len(), 2);
+    assert_eq!(x[0].0, "world");
+    assert_eq!(x[0].1, 3);
+    assert_eq!(x[1].0, "hello");
+    assert_eq!(x[1].1, 4);
+
+    let x = string_list(&["hello", "world"]);
+    assert_eq!(x.len(), 4);
+    assert_eq!(x[0], "I");
+    assert_eq!(x[1], "love");
+    assert_eq!(x[2], "Wasm");
+    assert_eq!(x[3], "!");
+
+    let x = record_list(&[
+        SomeRecord {
+            x: "guten tag!",
+            y: OtherRecordParam {
+                a0: 1,
+                a1: 2,
+                a2: 3,
+                a3: 4,
+                a4: 5,
+                b: "6",
+                c: &[7],
+            },
+            c1: 8,
+            c2: 9,
+            c3: 10,
+            c4: 11,
+        },
+        SomeRecord {
+            x: "guten morgen!",
+            y: OtherRecordParam {
+                a0: 12,
+                a1: 13,
+                a2: 14,
+                a3: 15,
+                a4: 16,
+                b: "17",
+                c: &[18, 19, 20],
+            },
+            c1: 21,
+            c2: 22,
+            c3: 23,
+            c4: 24,
+        },
+    ]);
+
+    assert_eq!(x.len(), 1);
+    assert_eq!(x[0].a0, 1);
+    assert_eq!(x[0].a1, 5);
+    assert_eq!(x[0].a2, 2);
+    assert_eq!(x[0].a3, 7);
+    assert_eq!(x[0].a4, 11);
+    assert_eq!(x[0].b, "hello!");
+    assert_eq!(x[0].c, &[1, 2, 3, 4, 5]);
+}

--- a/crates/test-modules/modules/crates/lists/Cargo.toml
+++ b/crates/test-modules/modules/crates/lists/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "lists"
+version = "0.1.0"
+authors = ["Peter Huene <peter@huene.dev>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+witx-bindgen-rust = { git = "https://github.com/bytecodealliance/witx-bindgen", branch = "main" }

--- a/crates/test-modules/modules/crates/lists/build.rs
+++ b/crates/test-modules/modules/crates/lists/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=crates/lists/lists.witx");
+}

--- a/crates/test-modules/modules/crates/lists/lists.witx
+++ b/crates/test-modules/modules/crates/lists/lists.witx
@@ -1,0 +1,53 @@
+list_u8_param: function(x: list<u8>)
+list_u16_param: function(x: list<u16>)
+list_u32_param: function(x: list<u32>)
+list_u64_param: function(x: list<u64>)
+list_s8_param: function(x: list<s8>)
+list_s16_param: function(x: list<s16>)
+list_s32_param: function(x: list<s32>)
+list_s64_param: function(x: list<s64>)
+
+list_u8_ret: function() -> list<u8>
+list_u16_ret: function() -> list<u16>
+list_u32_ret: function() -> list<u32>
+list_u64_ret: function() -> list<u64>
+list_s8_ret: function() -> list<s8>
+list_s16_ret: function() -> list<s16>
+list_s32_ret: function() -> list<s32>
+list_s64_ret: function() -> list<s64>
+
+tuple_list: function(x: list<tuple<u8, s8>>) -> list<tuple<s64, u32>>
+tuple_string_list: function(x: list<tuple<u8, string>>) -> list<tuple<string, u8>>
+string_list: function(x: list<string>) -> list<string>
+
+record some_record {
+  x: string,
+  y: other_record,
+  c1: u32,
+  c2: u64,
+  c3: s32,
+  c4: s64,
+}
+record other_record {
+  a0: u64,
+  a1: u32,
+  a2: u64,
+  a3: s32,
+  a4: s64,
+  b: string,
+  c: list<u8>,
+}
+record_list: function(x: list<some_record>) -> list<other_record>
+
+// variant some_variant {
+//   a(string),
+//   b,
+//   c(u32),
+//   d(list<other_variant>),
+// }
+// variant other_variant {
+//   a,
+//   b(u32),
+//   c(tuple<string, string>),
+// }
+// variant_list: function(x: other_variant) -> list<other_variant>

--- a/crates/test-modules/modules/crates/lists/src/lib.rs
+++ b/crates/test-modules/modules/crates/lists/src/lib.rs
@@ -1,0 +1,157 @@
+witx_bindgen_rust::export!("crates/lists/lists.witx");
+
+use lists::*;
+
+struct Component;
+
+impl Lists for Component {
+    fn list_u8_param(&self, x: Vec<u8>) {
+        assert_eq!(x, &[5, 4, 3, 2, 1]);
+    }
+    fn list_u16_param(&self, x: Vec<u16>) {
+        assert_eq!(x, &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+    }
+    fn list_u32_param(&self, x: Vec<u32>) {
+        assert_eq!(x, &[15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+    }
+    fn list_u64_param(&self, x: Vec<u64>) {
+        assert_eq!(
+            x,
+            &[20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+        );
+    }
+    fn list_s8_param(&self, x: Vec<i8>) {
+        assert_eq!(x, &[-1, 2, -3, 4, -5]);
+    }
+    fn list_s16_param(&self, x: Vec<i16>) {
+        assert_eq!(x, &[-1, 2, -3, 4, -5, 6, -7, 8, -9, 10]);
+    }
+    fn list_s32_param(&self, x: Vec<i32>) {
+        assert_eq!(
+            x,
+            &[-1, 2, -3, 4, -5, 6, -7, 8, -9, 10, -11, 12, -13, 14, -15]
+        );
+    }
+    fn list_s64_param(&self, x: Vec<i64>) {
+        assert_eq!(
+            x,
+            &[-1, 2, -3, 4, -5, 6, -7, 8, -9, 10, -11, 12, -13, 14, -15, 16, -17, 18, -19, 20]
+        );
+    }
+    fn list_u8_ret(&self) -> Vec<u8> {
+        vec![5, 4, 3, 2, 1]
+    }
+    fn list_u16_ret(&self) -> Vec<u16> {
+        vec![10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+    }
+    fn list_u32_ret(&self) -> Vec<u32> {
+        vec![15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+    }
+    fn list_u64_ret(&self) -> Vec<u64> {
+        vec![
+            20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
+        ]
+    }
+    fn list_s8_ret(&self) -> Vec<i8> {
+        vec![-1, 2, -3, 4, -5]
+    }
+    fn list_s16_ret(&self) -> Vec<i16> {
+        vec![-1, 2, -3, 4, -5, 6, -7, 8, -9, 10]
+    }
+    fn list_s32_ret(&self) -> Vec<i32> {
+        vec![-1, 2, -3, 4, -5, 6, -7, 8, -9, 10, -11, 12, -13, 14, -15]
+    }
+    fn list_s64_ret(&self) -> Vec<i64> {
+        vec![
+            -1, 2, -3, 4, -5, 6, -7, 8, -9, 10, -11, 12, -13, 14, -15, 16, -17, 18, -19, 20,
+        ]
+    }
+    fn tuple_list(&self, x: Vec<(u8, i8)>) -> Vec<(i64, u32)> {
+        assert_eq!(
+            x,
+            &[
+                (1, -2),
+                (3, 4),
+                (5, -6),
+                (7, 8),
+                (9, -10),
+                (11, 12),
+                (13, -14)
+            ]
+        );
+        vec![
+            (-1, 2),
+            (3, 4),
+            (-5, 6),
+            (7, 8),
+            (-9, 10),
+            (11, 12),
+            (-13, 14),
+        ]
+    }
+    fn tuple_string_list(&self, x: Vec<(u8, String)>) -> Vec<(String, u8)> {
+        assert_eq!(x.len(), 2);
+        assert_eq!(x[0].0, 0);
+        assert_eq!(x[0].1, "hello");
+        assert_eq!(x[1].0, 1);
+        assert_eq!(x[1].1, "world");
+        vec![("world".to_string(), 3), ("hello".to_string(), 4)]
+    }
+    fn string_list(&self, x: Vec<String>) -> Vec<String> {
+        assert_eq!(x.len(), 2);
+        assert_eq!(x[0], "hello");
+        assert_eq!(x[1], "world");
+        vec![
+            "I".to_string(),
+            "love".to_string(),
+            "Wasm".to_string(),
+            "!".to_string(),
+        ]
+    }
+    fn record_list(&self, x: Vec<SomeRecord>) -> Vec<OtherRecord> {
+        assert_eq!(x.len(), 2);
+        assert_eq!(x[0].x, "guten tag!");
+        assert_eq!(x[0].y.a0, 1);
+        assert_eq!(x[0].y.a1, 2);
+        assert_eq!(x[0].y.a2, 3);
+        assert_eq!(x[0].y.a3, 4);
+        assert_eq!(x[0].y.a4, 5);
+        assert_eq!(x[0].y.b, "6");
+        assert_eq!(x[0].y.c.len(), 1);
+        assert_eq!(x[0].y.c[0], 7);
+        assert_eq!(x[0].c1, 8);
+        assert_eq!(x[0].c2, 9);
+        assert_eq!(x[0].c3, 10);
+        assert_eq!(x[0].c4, 11);
+        assert_eq!(x[1].x, "guten morgen!");
+        assert_eq!(x[1].y.a0, 12);
+        assert_eq!(x[1].y.a1, 13);
+        assert_eq!(x[1].y.a2, 14);
+        assert_eq!(x[1].y.a3, 15);
+        assert_eq!(x[1].y.a4, 16);
+        assert_eq!(x[1].y.b, "17");
+        assert_eq!(x[1].y.c.len(), 3);
+        assert_eq!(x[1].y.c[0], 18);
+        assert_eq!(x[1].y.c[1], 19);
+        assert_eq!(x[1].y.c[2], 20);
+        assert_eq!(x[1].c1, 21);
+        assert_eq!(x[1].c2, 22);
+        assert_eq!(x[1].c3, 23);
+        assert_eq!(x[1].c4, 24);
+
+        vec![OtherRecord {
+            a0: 1,
+            a1: 5,
+            a2: 2,
+            a3: 7,
+            a4: 11,
+            b: "hello!".to_string(),
+            c: vec![1, 2, 3, 4, 5],
+        }]
+    }
+}
+
+fn lists() -> &'static impl Lists {
+    static INSTANCE: Component = Component;
+    &INSTANCE
+}

--- a/crates/test-modules/src/lib.rs
+++ b/crates/test-modules/src/lib.rs
@@ -92,4 +92,9 @@ mod tests {
     fn flags() -> Result<()> {
         run(&link("flags-main", &["flags"])?)
     }
+
+    #[test]
+    fn lists() -> Result<()> {
+        run(&link("lists-main", &["lists"])?)
+    }
 }

--- a/crates/wasmlink/Cargo.toml
+++ b/crates/wasmlink/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.40"
+itertools = "0.10.1"
 lazy_static = "1.4.0"
 petgraph = "0.5.1"
 wasm-encoder = "0.4.1"

--- a/crates/wasmlink/src/adapted/generator.rs
+++ b/crates/wasmlink/src/adapted/generator.rs
@@ -1,14 +1,24 @@
+use crate::adapted::FREE_EXPORT_NAME;
+use itertools::Either;
 use witx2::{
     abi::{Bindgen, CallMode, Instruction, WasmSignature, WasmType},
-    Function, Interface, RecordKind, SizeAlign, Type, TypeDefKind, TypeId,
+    Function, Interface, Record, RecordKind, SizeAlign, Type, TypeDefKind, TypeId,
 };
-
-use crate::adapted::FREE_EXPORT_NAME;
 
 // The parent's memory is imported, so it is always index 0 for the adapter logic
 const PARENT_MEMORY_INDEX: u32 = 0;
 // The adapted module's memory is aliased, so it is always index 1 for the adapter logic
 const ADAPTED_MEMORY_INDEX: u32 = 1;
+
+// Represents a placeholder "global" that will be translated to the local storing the
+// base pointer to the list being written to when lowering/lifting non-canonical lists
+const BASE_POINTER_GLOBAL: u32 = 0;
+// Represents a placeholder "global" that will be translated to a load instruction
+// from the list being read from when lowering/lifting non-canonical lists
+// This value is the *base* for offsets within the element being lifted/lowered.
+// For example, a reference to global `1` means offset 0 from the start of the element
+// and global `5` means offset 4 from the start of the element.
+const ELEMENT_GLOBAL: u32 = 1;
 
 fn to_val_type(ty: &WasmType) -> wasm_encoder::ValType {
     match ty {
@@ -65,6 +75,54 @@ fn param_to_operand(interface: &Interface, index: u32, ty: &Type) -> (u32, Opera
     }
 }
 
+fn offsets_for_type(interface: &Interface, sizes: &SizeAlign, ty: &Type) -> Vec<(u32, WasmType)> {
+    fn _offsets_for_type(
+        interface: &Interface,
+        sizes: &SizeAlign,
+        ty: &Type,
+        current: u32,
+        offsets: &mut Vec<(u32, WasmType)>,
+    ) {
+        match ty {
+            Type::Id(id) => match &interface.types[*id].kind {
+                TypeDefKind::Type(t) => _offsets_for_type(interface, sizes, t, current, offsets),
+                TypeDefKind::List(_) => {
+                    offsets.push((current, WasmType::I32));
+                    offsets.push((current + 4, WasmType::I32));
+                }
+                TypeDefKind::Pointer(_) | TypeDefKind::ConstPointer(_) => {
+                    offsets.push((current, WasmType::I32));
+                }
+                TypeDefKind::PushBuffer(_) | TypeDefKind::PullBuffer(_) => todo!(),
+                TypeDefKind::Record(r) => {
+                    for (f, o) in r.fields.iter().zip(sizes.field_offsets(r).iter()) {
+                        _offsets_for_type(interface, sizes, &f.ty, current + *o as u32, offsets);
+                    }
+                }
+                TypeDefKind::Variant(_) => todo!(),
+            },
+            Type::S8
+            | Type::U8
+            | Type::S16
+            | Type::U16
+            | Type::S32
+            | Type::U32
+            | Type::Char
+            | Type::Handle(_)
+            | Type::CChar
+            | Type::Usize => offsets.push((current, WasmType::I32)),
+            Type::U64 | Type::S64 => offsets.push((current, WasmType::I64)),
+            Type::F32 => offsets.push((current, WasmType::F32)),
+            Type::F64 => offsets.push((current, WasmType::F64)),
+        }
+    }
+
+    let mut offsets = Vec::new();
+    _offsets_for_type(interface, sizes, ty, 0, &mut offsets);
+    offsets
+}
+
+#[derive(Debug, Copy, Clone)]
 enum LoadType {
     I32,
     I32_8U,
@@ -76,6 +134,7 @@ enum LoadType {
     F64,
 }
 
+#[derive(Debug, Copy, Clone)]
 enum StoreType {
     I32,
     I32_8,
@@ -103,6 +162,8 @@ pub enum Operand {
     Pointer { addr: u32, memory: u32 },
     List { addr: u32, len: u32 },
     Record { fields: Vec<Box<Operand>> },
+    Global(u32),
+    GlobalPointer { addr: u32, memory: u32 },
 }
 
 impl Operand {
@@ -113,66 +174,80 @@ impl Operand {
         }
     }
 
-    fn load(&self, instructions: &mut Vec<wasm_encoder::Instruction>) {
+    fn locals(&self) -> Vec<u32> {
+        fn _locals(o: &Operand, v: &mut Vec<u32>) {
+            match o {
+                Operand::Local(i) | Operand::Pointer { addr: i, .. } => v.push(*i),
+                Operand::List { addr, len } => {
+                    v.push(*addr);
+                    v.push(*len);
+                }
+                Operand::Record { fields } => {
+                    for f in fields {
+                        _locals(f, v);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let mut v = Vec::new();
+        _locals(self, &mut v);
+        v
+    }
+
+    fn load(&self, generator: &mut CodeGenerator) {
         match self {
             Self::Local(i) | Self::Pointer { addr: i, .. } => {
-                instructions.push(wasm_encoder::Instruction::LocalGet(*i));
+                generator.emit_instruction(wasm_encoder::Instruction::LocalGet(*i));
             }
             Self::I32Const(i) => {
-                instructions.push(wasm_encoder::Instruction::I32Const(*i));
+                generator.emit_instruction(wasm_encoder::Instruction::I32Const(*i));
             }
-            Self::List { .. } => panic!("list operands must be split"),
+            Self::List { .. } => panic!("list operands must be lowered"),
             Self::Record { fields } => {
                 for field in fields {
-                    field.load(instructions);
+                    field.load(generator);
                 }
+            }
+            Self::Global(i) | Self::GlobalPointer { addr: i, .. } => {
+                generator.emit_instruction(wasm_encoder::Instruction::GlobalGet(*i));
             }
         }
     }
 
-    fn store<'a>(
-        &self,
-        generator: &mut CodeGenerator<'_>,
-        addr: &Operand,
-        types: &mut impl Iterator<Item = &'a WasmType>,
-        offset: &mut u32,
-        alignment: u32,
-    ) {
+    fn lower_list(self) -> (Self, Self) {
         match self {
-            Self::Local(i) | Self::Pointer { addr: i, .. } => {
-                let ty = types.next().expect("incorrect number of types");
-                assert!(*ty == generator.local_type(*i));
-
-                generator.emit_store(addr, *offset, self, ty.into());
-                *offset += alignment;
-            }
-            Self::List { .. } => {
-                let (list, len) = self.split_list();
-                list.store(generator, addr, types, offset, alignment);
-                len.store(generator, addr, types, offset, alignment);
-            }
-            Self::Record { fields } => {
-                for field in fields {
-                    field.store(generator, addr, types, offset, alignment);
-                }
-            }
-            _ => panic!("expected a local, list, or record"),
+            Self::List { addr, len } => (Self::Local(addr), Self::Local(len)),
+            Self::Global(i) => (Self::Global(i), Self::Global(i + 4 /* offset */)),
+            _ => panic!("expected a list operand to lower, found: {:?}", self),
         }
     }
 
-    fn split_list(&self) -> (Self, Self) {
+    fn lower_record<'a>(
+        self,
+        sizes: &SizeAlign,
+        record: &'a Record,
+    ) -> impl Iterator<Item = Operand> + 'a {
         match self {
-            Self::List { addr, len } => (Self::Local(*addr), Self::Local(*len)),
-            _ => panic!("expected a list operand to split"),
+            Self::Record { fields } => Either::Left(fields.into_iter().map(|f| *f)),
+            Self::Global(i) => Either::Right(
+                sizes
+                    .field_offsets(record)
+                    .into_iter()
+                    .map(move |o| Operand::Global(i + o as u32)),
+            ),
+            _ => panic!("expected a record operand to lower, found: {:?}", self),
         }
     }
 }
 
 pub struct CodeGenerator<'a> {
     params: Vec<Operand>,
-    signature: WasmSignature,
+    signature: &'a WasmSignature,
     locals: Vec<WasmType>,
-    instructions: Vec<wasm_encoder::Instruction<'a>>,
+    instructions: Vec<Vec<wasm_encoder::Instruction<'a>>>,
+    blocks: Vec<(Vec<Operand>, Vec<wasm_encoder::Instruction<'a>>)>,
     locals_start_index: u32,
     func_index: u32,
     parent_realloc_index: u32,
@@ -184,12 +259,11 @@ impl<'a> CodeGenerator<'a> {
     pub fn new(
         interface: &Interface,
         func: &Function,
+        signature: &'a WasmSignature,
         func_index: u32,
         parent_realloc_index: u32,
         realloc_index: u32,
     ) -> Self {
-        let signature = interface.wasm_signature(CallMode::WasmImport, func);
-
         let mut locals_start_index = 0;
         let params = func
             .params
@@ -207,13 +281,14 @@ impl<'a> CodeGenerator<'a> {
         }
 
         let mut sizes = SizeAlign::default();
-        sizes.fill(CallMode::WasmImport, interface);
+        sizes.fill(CallMode::WasmExport, interface);
 
         Self {
             params,
             signature,
             locals: Vec::new(),
             instructions: Vec::new(),
+            blocks: Vec::new(),
             locals_start_index,
             func_index,
             parent_realloc_index,
@@ -222,11 +297,13 @@ impl<'a> CodeGenerator<'a> {
         }
     }
 
-    pub fn into_function(self) -> wasm_encoder::Function {
+    pub fn into_function(mut self) -> wasm_encoder::Function {
         let mut function =
             wasm_encoder::Function::new(self.locals.iter().map(|ty| (1, to_val_type(ty))));
 
-        for inst in self.instructions {
+        assert!(self.instructions.len() == 1);
+
+        for inst in self.instructions.swap_remove(0) {
             function.instruction(inst);
         }
 
@@ -247,65 +324,101 @@ impl<'a> CodeGenerator<'a> {
         }
     }
 
-    fn emit_load(&mut self, addr: &Operand, offset: u32, ty: LoadType) -> u32 {
-        match addr {
-            Operand::Pointer { addr, memory } => {
-                self.instructions
-                    .push(wasm_encoder::Instruction::LocalGet(*addr));
-
-                let memarg = wasm_encoder::MemArg {
-                    offset: offset as u32,
-                    align: match ty {
-                        LoadType::I32 => 2,
-                        LoadType::I32_8S | LoadType::I32_8U => 0,
-                        LoadType::I32_16S | LoadType::I32_16U => 1,
-                        LoadType::I64 => 3,
-                        LoadType::F32 => 2,
-                        LoadType::F64 => 3,
-                    },
-                    memory_index: *memory,
-                };
-
-                let (wasm_ty, inst) = match ty {
-                    LoadType::I32 => (WasmType::I32, wasm_encoder::Instruction::I32Load(memarg)),
-                    LoadType::I32_8U => {
-                        (WasmType::I32, wasm_encoder::Instruction::I32Load8_U(memarg))
-                    }
-                    LoadType::I32_8S => {
-                        (WasmType::I32, wasm_encoder::Instruction::I32Load8_S(memarg))
-                    }
-                    LoadType::I32_16U => (
-                        WasmType::I32,
-                        wasm_encoder::Instruction::I32Load16_U(memarg),
-                    ),
-                    LoadType::I32_16S => (
-                        WasmType::I32,
-                        wasm_encoder::Instruction::I32Load16_S(memarg),
-                    ),
-                    LoadType::I64 => (WasmType::I64, wasm_encoder::Instruction::I64Load(memarg)),
-                    LoadType::F32 => (WasmType::F32, wasm_encoder::Instruction::F32Load(memarg)),
-                    LoadType::F64 => (WasmType::F64, wasm_encoder::Instruction::F64Load(memarg)),
-                };
-
-                self.instructions.push(inst);
-
-                let storage = self.alloc_local(wasm_ty);
-
-                self.instructions
-                    .push(wasm_encoder::Instruction::LocalSet(storage));
-
-                storage
-            }
-            _ => panic!("operand must be a pointer"),
+    fn emit_instruction(&mut self, inst: wasm_encoder::Instruction<'a>) {
+        if self.instructions.is_empty() {
+            self.instructions.push(Vec::new());
         }
+        self.instructions.last_mut().unwrap().push(inst);
     }
 
-    fn emit_store(&mut self, addr: &Operand, offset: u32, operand: &Operand, ty: StoreType) {
-        addr.load(&mut self.instructions);
-        operand.load(&mut self.instructions);
+    fn emit_load(&mut self, offset: u32, ty: LoadType, memory_index: u32) -> WasmType {
+        let memarg = wasm_encoder::MemArg {
+            offset: offset as u32,
+            align: match ty {
+                LoadType::I32 => 2,
+                LoadType::I32_8S | LoadType::I32_8U => 0,
+                LoadType::I32_16S | LoadType::I32_16U => 1,
+                LoadType::I64 => 3,
+                LoadType::F32 => 2,
+                LoadType::F64 => 3,
+            },
+            memory_index,
+        };
+
+        let (wasm_ty, inst) = match ty {
+            LoadType::I32 => (WasmType::I32, wasm_encoder::Instruction::I32Load(memarg)),
+            LoadType::I32_8U => (WasmType::I32, wasm_encoder::Instruction::I32Load8_U(memarg)),
+            LoadType::I32_8S => (WasmType::I32, wasm_encoder::Instruction::I32Load8_S(memarg)),
+            LoadType::I32_16U => (
+                WasmType::I32,
+                wasm_encoder::Instruction::I32Load16_U(memarg),
+            ),
+            LoadType::I32_16S => (
+                WasmType::I32,
+                wasm_encoder::Instruction::I32Load16_S(memarg),
+            ),
+            LoadType::I64 => (WasmType::I64, wasm_encoder::Instruction::I64Load(memarg)),
+            LoadType::F32 => (WasmType::F32, wasm_encoder::Instruction::F32Load(memarg)),
+            LoadType::F64 => (WasmType::F64, wasm_encoder::Instruction::F64Load(memarg)),
+        };
+
+        self.emit_instruction(inst);
+        wasm_ty
+    }
+
+    fn emit_load_to_local(&mut self, addr: &Operand, offset: u32, ty: LoadType) -> u32 {
+        let (addr, memory) = match addr {
+            Operand::Pointer { addr, memory } => (Operand::Local(*addr), memory),
+            Operand::GlobalPointer { addr, memory } => (Operand::Global(*addr), memory),
+            _ => panic!("expected pointer for load, found: {:?}", addr),
+        };
+
+        addr.load(self);
+
+        let ty = self.emit_load(offset, ty, *memory);
+        let local = self.alloc_local(ty);
+        self.emit_instruction(wasm_encoder::Instruction::LocalSet(local));
+        local
+    }
+
+    fn emit_store(&mut self, offset: u32, ty: StoreType, memory_index: u32) {
+        let memarg = wasm_encoder::MemArg {
+            offset: offset as u32,
+            align: match ty {
+                StoreType::I32 => 2,
+                StoreType::I32_8 => 0,
+                StoreType::I32_16 => 1,
+                StoreType::I64 => 3,
+                StoreType::F32 => 2,
+                StoreType::F64 => 3,
+            },
+            memory_index,
+        };
+
+        let inst = match ty {
+            StoreType::I32 => wasm_encoder::Instruction::I32Store(memarg),
+            StoreType::I32_8 => wasm_encoder::Instruction::I32Store8(memarg),
+            StoreType::I32_16 => wasm_encoder::Instruction::I32Store16(memarg),
+            StoreType::I64 => wasm_encoder::Instruction::I64Store(memarg),
+            StoreType::F32 => wasm_encoder::Instruction::F32Store(memarg),
+            StoreType::F64 => wasm_encoder::Instruction::F64Store(memarg),
+        };
+
+        self.emit_instruction(inst);
+    }
+
+    fn emit_store_from_local(
+        &mut self,
+        addr: &Operand,
+        offset: u32,
+        local: &Operand,
+        ty: StoreType,
+    ) {
+        addr.load(self);
+        local.load(self);
 
         match addr {
-            Operand::Pointer { memory, .. } => {
+            Operand::Pointer { memory, .. } | Operand::GlobalPointer { memory, .. } => {
                 let memarg = wasm_encoder::MemArg {
                     offset: offset as u32,
                     align: match ty {
@@ -328,10 +441,207 @@ impl<'a> CodeGenerator<'a> {
                     StoreType::F64 => wasm_encoder::Instruction::F64Store(memarg),
                 };
 
-                self.instructions.push(inst);
+                self.emit_instruction(inst);
             }
-            _ => panic!("expected a pointer for first operand"),
+            _ => panic!("expected a pointer for first operand, found: {:?}", addr),
         }
+    }
+
+    fn emit_copy_list(
+        &mut self,
+        size: u32,
+        alignment: u32,
+        list: &Operand,
+        len: &Operand,
+        lowering: bool,
+        offsets: Option<Vec<(u32, WasmType)>>,
+    ) -> u32 {
+        self.emit_instruction(wasm_encoder::Instruction::I32Const(0)); // Previous ptr
+        self.emit_instruction(wasm_encoder::Instruction::I32Const(0)); // Previous size
+
+        let ptr = self.alloc_local(WasmType::I32);
+        len.load(self);
+        if size > 1 {
+            self.emit_instruction(wasm_encoder::Instruction::I32Const(size as i32));
+            self.emit_instruction(wasm_encoder::Instruction::I32Mul);
+        }
+        self.emit_instruction(wasm_encoder::Instruction::I32Const(alignment as i32));
+        self.emit_instruction(wasm_encoder::Instruction::Call(if lowering {
+            self.realloc_index
+        } else {
+            self.parent_realloc_index
+        }));
+        // TODO: trap on alloc failure
+
+        // If given element offsets, copy each element individually in a loop
+        if let Some(offsets) = offsets {
+            self.emit_instruction(wasm_encoder::Instruction::LocalSet(ptr));
+
+            let counter = self.alloc_local(WasmType::I32);
+            self.emit_instruction(wasm_encoder::Instruction::I32Const(0));
+            self.emit_instruction(wasm_encoder::Instruction::LocalSet(counter));
+            let element_offset = self.alloc_local(WasmType::I32);
+            self.emit_instruction(wasm_encoder::Instruction::I32Const(0));
+            self.emit_instruction(wasm_encoder::Instruction::LocalSet(element_offset));
+
+            self.emit_instruction(wasm_encoder::Instruction::Block(
+                wasm_encoder::BlockType::Empty,
+            ));
+            self.emit_instruction(wasm_encoder::Instruction::Loop(
+                wasm_encoder::BlockType::Empty,
+            ));
+
+            // Wasm: if counter >= len { break }
+            self.emit_instruction(wasm_encoder::Instruction::LocalGet(counter));
+            len.load(self);
+            self.emit_instruction(wasm_encoder::Instruction::I32Eq);
+            self.emit_instruction(wasm_encoder::Instruction::BrIf(1));
+
+            // Add the block to the loop, replacing global references with the source and destination
+            assert!(!self.blocks.is_empty());
+            let (operands, block) = self.blocks.pop().unwrap();
+            for mut inst in block {
+                // Fix up any load and store instructions to use the correct memory
+                match &mut inst {
+                    wasm_encoder::Instruction::I32Store8(arg)
+                    | wasm_encoder::Instruction::I32Store16(arg)
+                    | wasm_encoder::Instruction::I32Store(arg)
+                    | wasm_encoder::Instruction::I64Store8(arg)
+                    | wasm_encoder::Instruction::I64Store16(arg)
+                    | wasm_encoder::Instruction::I64Store32(arg)
+                    | wasm_encoder::Instruction::I64Store(arg)
+                    | wasm_encoder::Instruction::F32Store(arg)
+                    | wasm_encoder::Instruction::F64Store(arg) => {
+                        arg.memory_index = if lowering {
+                            ADAPTED_MEMORY_INDEX
+                        } else {
+                            PARENT_MEMORY_INDEX
+                        };
+                    }
+                    wasm_encoder::Instruction::I32Load8_S(arg)
+                    | wasm_encoder::Instruction::I32Load8_U(arg)
+                    | wasm_encoder::Instruction::I32Load16_S(arg)
+                    | wasm_encoder::Instruction::I32Load16_U(arg)
+                    | wasm_encoder::Instruction::I32Load(arg)
+                    | wasm_encoder::Instruction::I64Load8_S(arg)
+                    | wasm_encoder::Instruction::I64Load8_U(arg)
+                    | wasm_encoder::Instruction::I64Load16_S(arg)
+                    | wasm_encoder::Instruction::I64Load16_U(arg)
+                    | wasm_encoder::Instruction::I64Load32_S(arg)
+                    | wasm_encoder::Instruction::I64Load32_U(arg)
+                    | wasm_encoder::Instruction::I64Load(arg)
+                    | wasm_encoder::Instruction::F32Load(arg)
+                    | wasm_encoder::Instruction::F64Load(arg) => {
+                        arg.memory_index = if lowering {
+                            PARENT_MEMORY_INDEX
+                        } else {
+                            ADAPTED_MEMORY_INDEX
+                        };
+                    }
+                    _ => {}
+                };
+
+                match inst {
+                    wasm_encoder::Instruction::GlobalGet(BASE_POINTER_GLOBAL) => {
+                        self.emit_instruction(wasm_encoder::Instruction::LocalGet(if lowering {
+                            ptr
+                        } else {
+                            list.local().unwrap()
+                        }));
+                        self.emit_instruction(wasm_encoder::Instruction::LocalGet(element_offset));
+                        self.emit_instruction(wasm_encoder::Instruction::I32Add);
+                    }
+                    wasm_encoder::Instruction::GlobalGet(n) => {
+                        let (offset, ty) = offsets
+                            .iter()
+                            .find(|(o, _)| *o == n - ELEMENT_GLOBAL)
+                            .unwrap();
+                        assert!(lowering);
+                        list.load(self);
+                        self.emit_instruction(wasm_encoder::Instruction::LocalGet(element_offset));
+                        self.emit_instruction(wasm_encoder::Instruction::I32Add);
+                        self.emit_load(
+                            *offset,
+                            match *ty {
+                                WasmType::I32 => LoadType::I32,
+                                WasmType::I64 => LoadType::I64,
+                                WasmType::F32 => LoadType::F32,
+                                WasmType::F64 => LoadType::F64,
+                            },
+                            PARENT_MEMORY_INDEX,
+                        );
+                    }
+                    _ => {
+                        self.emit_instruction(inst);
+                    }
+                }
+            }
+
+            if lowering {
+                // Block operand stack should be empty when lowering
+                assert!(operands.is_empty());
+            } else {
+                assert_eq!(operands.len(), 1);
+
+                for (index, local) in operands[0].locals().into_iter().enumerate() {
+                    let (offset, ty) = &offsets[index];
+                    self.emit_instruction(wasm_encoder::Instruction::LocalGet(ptr));
+                    self.emit_instruction(wasm_encoder::Instruction::LocalGet(element_offset));
+                    self.emit_instruction(wasm_encoder::Instruction::I32Add);
+                    self.emit_instruction(wasm_encoder::Instruction::LocalGet(local));
+                    self.emit_store(
+                        *offset,
+                        match *ty {
+                            WasmType::I32 => StoreType::I32,
+                            WasmType::I64 => StoreType::I64,
+                            WasmType::F32 => StoreType::F32,
+                            WasmType::F64 => StoreType::F64,
+                        },
+                        PARENT_MEMORY_INDEX,
+                    );
+                }
+            }
+
+            // Wasm: counter += 1
+            self.emit_instruction(wasm_encoder::Instruction::LocalGet(counter));
+            self.emit_instruction(wasm_encoder::Instruction::I32Const(1));
+            self.emit_instruction(wasm_encoder::Instruction::I32Add);
+            self.emit_instruction(wasm_encoder::Instruction::LocalSet(counter));
+
+            // Wasm: offset += size
+            self.emit_instruction(wasm_encoder::Instruction::LocalGet(element_offset));
+            self.emit_instruction(wasm_encoder::Instruction::I32Const(size as i32));
+            self.emit_instruction(wasm_encoder::Instruction::I32Add);
+            self.emit_instruction(wasm_encoder::Instruction::LocalSet(element_offset));
+
+            // Wasm: goto loop
+            self.emit_instruction(wasm_encoder::Instruction::Br(0));
+            self.emit_instruction(wasm_encoder::Instruction::End);
+            self.emit_instruction(wasm_encoder::Instruction::End);
+        } else {
+            // No offsets given; do a memcpy
+            self.emit_instruction(wasm_encoder::Instruction::LocalTee(ptr));
+            list.load(self);
+            len.load(self);
+            if size > 1 {
+                self.emit_instruction(wasm_encoder::Instruction::I32Const(size as i32));
+                self.emit_instruction(wasm_encoder::Instruction::I32Mul);
+            }
+            self.emit_instruction(wasm_encoder::Instruction::MemoryCopy {
+                src: if lowering {
+                    PARENT_MEMORY_INDEX
+                } else {
+                    ADAPTED_MEMORY_INDEX
+                },
+                dst: if lowering {
+                    ADAPTED_MEMORY_INDEX
+                } else {
+                    PARENT_MEMORY_INDEX
+                },
+            });
+        }
+
+        ptr
     }
 }
 
@@ -340,7 +650,7 @@ impl<'a> Bindgen for CodeGenerator<'a> {
 
     fn emit(
         &mut self,
-        _iface: &Interface,
+        interface: &Interface,
         inst: &Instruction<'_>,
         operands: &mut Vec<Self::Operand>,
         results: &mut Vec<Self::Operand>,
@@ -355,83 +665,108 @@ impl<'a> Bindgen for CodeGenerator<'a> {
             Instruction::Bitcasts { .. } => todo!(),
             Instruction::ConstZero { .. } => todo!(),
             Instruction::I32Load { offset } => {
-                results.push(Operand::Local(self.emit_load(
+                results.push(Operand::Local(self.emit_load_to_local(
                     &operands[0],
                     *offset as u32,
                     LoadType::I32,
                 )));
             }
             Instruction::I32Load8U { offset } => {
-                results.push(Operand::Local(self.emit_load(
+                results.push(Operand::Local(self.emit_load_to_local(
                     &operands[0],
                     *offset as u32,
                     LoadType::I32_8U,
                 )));
             }
             Instruction::I32Load8S { offset } => {
-                results.push(Operand::Local(self.emit_load(
+                results.push(Operand::Local(self.emit_load_to_local(
                     &operands[0],
                     *offset as u32,
                     LoadType::I32_8S,
                 )));
             }
             Instruction::I32Load16U { offset } => {
-                results.push(Operand::Local(self.emit_load(
+                results.push(Operand::Local(self.emit_load_to_local(
                     &operands[0],
                     *offset as u32,
                     LoadType::I32_16U,
                 )));
             }
             Instruction::I32Load16S { offset } => {
-                results.push(Operand::Local(self.emit_load(
+                results.push(Operand::Local(self.emit_load_to_local(
                     &operands[0],
                     *offset as u32,
                     LoadType::I32_16S,
                 )));
             }
             Instruction::I64Load { offset } => {
-                results.push(Operand::Local(self.emit_load(
+                results.push(Operand::Local(self.emit_load_to_local(
                     &operands[0],
                     *offset as u32,
                     LoadType::I64,
                 )));
             }
             Instruction::F32Load { offset } => {
-                results.push(Operand::Local(self.emit_load(
+                results.push(Operand::Local(self.emit_load_to_local(
                     &operands[0],
                     *offset as u32,
                     LoadType::F32,
                 )));
             }
             Instruction::F64Load { offset } => {
-                results.push(Operand::Local(self.emit_load(
+                results.push(Operand::Local(self.emit_load_to_local(
                     &operands[0],
                     *offset as u32,
                     LoadType::F64,
                 )));
             }
             Instruction::I32Store { offset } => {
-                self.emit_store(&operands[0], *offset as u32, &operands[1], StoreType::I32);
+                self.emit_store_from_local(
+                    &operands[1],
+                    *offset as u32,
+                    &operands[0],
+                    StoreType::I32,
+                );
             }
             Instruction::I32Store8 { offset } => {
-                self.emit_store(&operands[0], *offset as u32, &operands[1], StoreType::I32_8);
+                self.emit_store_from_local(
+                    &operands[1],
+                    *offset as u32,
+                    &operands[0],
+                    StoreType::I32_8,
+                );
             }
             Instruction::I32Store16 { offset } => {
-                self.emit_store(
-                    &operands[0],
-                    *offset as u32,
+                self.emit_store_from_local(
                     &operands[1],
+                    *offset as u32,
+                    &operands[0],
                     StoreType::I32_16,
                 );
             }
             Instruction::I64Store { offset } => {
-                self.emit_store(&operands[0], *offset as u32, &operands[1], StoreType::I64);
+                self.emit_store_from_local(
+                    &operands[1],
+                    *offset as u32,
+                    &operands[0],
+                    StoreType::I64,
+                );
             }
             Instruction::F32Store { offset } => {
-                self.emit_store(&operands[0], *offset as u32, &operands[1], StoreType::F32);
+                self.emit_store_from_local(
+                    &operands[1],
+                    *offset as u32,
+                    &operands[0],
+                    StoreType::F32,
+                );
             }
             Instruction::F64Store { offset } => {
-                self.emit_store(&operands[0], *offset as u32, &operands[1], StoreType::F64);
+                self.emit_store_from_local(
+                    &operands[1],
+                    *offset as u32,
+                    &operands[0],
+                    StoreType::F64,
+                );
             }
             // As we're going to and from the same ABI, perform no conversions for now
             Instruction::I32FromChar
@@ -462,7 +797,8 @@ impl<'a> Bindgen for CodeGenerator<'a> {
             | Instruction::UsizeFromI32 => {
                 results.push(match &operands[0] {
                     Operand::Local(i) => Operand::Local(*i),
-                    _ => panic!("expected a local"),
+                    Operand::Global(i) => Operand::Global(*i),
+                    _ => panic!("expected a local or global, found: {:?}", operands[0]),
                 });
             }
             Instruction::I32FromBorrowedHandle { .. } => todo!(),
@@ -470,113 +806,102 @@ impl<'a> Bindgen for CodeGenerator<'a> {
             Instruction::HandleOwnedFromI32 { .. } => todo!(),
             Instruction::HandleBorrowedFromI32 { .. } => todo!(),
             Instruction::ListCanonLower { element, realloc } => {
-                // Lifting goes from parent module to adapted module
+                // Lowering goes from parent module to adapted module
                 assert_eq!(*realloc, Some(super::REALLOC_EXPORT_NAME));
 
                 let (size, alignment) = match element {
                     Type::Char => (1, 1), // UTF-8
-                    _ => (self.sizes.size(element), self.sizes.align(element)),
+                    _ => (
+                        self.sizes.size(element) as u32,
+                        self.sizes.align(element) as u32,
+                    ),
                 };
 
-                self.instructions
-                    .push(wasm_encoder::Instruction::I32Const(0)); // Previous ptr
-                self.instructions
-                    .push(wasm_encoder::Instruction::I32Const(0)); // Previous size
-
-                let (operand, operand_len) = operands[0].split_list();
-
-                let ptr = self.alloc_local(WasmType::I32);
-                operand_len.load(&mut self.instructions);
-                if size > 1 {
-                    self.instructions
-                        .push(wasm_encoder::Instruction::I32Const(size as i32));
-                    self.instructions.push(wasm_encoder::Instruction::I32Mul);
-                }
-                self.instructions
-                    .push(wasm_encoder::Instruction::I32Const(alignment as i32));
-                self.instructions
-                    .push(wasm_encoder::Instruction::Call(self.realloc_index));
-
-                // TODO: trap on alloc failure
-                self.instructions
-                    .push(wasm_encoder::Instruction::LocalTee(ptr));
-                operand.load(&mut self.instructions);
-                operand_len.load(&mut self.instructions);
-                self.instructions
-                    .push(wasm_encoder::Instruction::MemoryCopy {
-                        src: PARENT_MEMORY_INDEX,
-                        dst: ADAPTED_MEMORY_INDEX,
-                    });
+                let (list, len) = operands.swap_remove(0).lower_list();
+                let ptr = self.emit_copy_list(size, alignment, &list, &len, true, None);
 
                 results.push(Operand::Pointer {
                     addr: ptr,
                     memory: ADAPTED_MEMORY_INDEX,
                 });
-                results.push(operand_len);
+                results.push(len);
             }
-            Instruction::ListLower { .. } => unreachable!(),
+            Instruction::ListLower { element, realloc } => {
+                // Lowering goes from parent module to adapted module
+                assert_eq!(*realloc, Some(super::REALLOC_EXPORT_NAME));
+
+                let offsets = offsets_for_type(interface, &self.sizes, element);
+                let size = self.sizes.size(element) as u32;
+                let alignment = self.sizes.align(element) as u32;
+
+                let (list, len) = operands.swap_remove(0).lower_list();
+                let ptr = self.emit_copy_list(size, alignment, &list, &len, true, Some(offsets));
+
+                results.push(Operand::Pointer {
+                    addr: ptr,
+                    memory: ADAPTED_MEMORY_INDEX,
+                });
+                results.push(len);
+            }
             Instruction::ListCanonLift { element, free } => {
-                // Lifting goes from adapted module to parent module
                 assert_eq!(*free, Some(FREE_EXPORT_NAME));
 
                 let (size, alignment) = match element {
                     Type::Char => (1, 1), // UTF-8
-                    _ => (self.sizes.size(element), self.sizes.align(element)),
+                    _ => (
+                        self.sizes.size(element) as u32,
+                        self.sizes.align(element) as u32,
+                    ),
                 };
 
-                self.instructions
-                    .push(wasm_encoder::Instruction::I32Const(0)); // Previous ptr
-                self.instructions
-                    .push(wasm_encoder::Instruction::I32Const(0)); // Previous size
-
-                let ptr = self.alloc_local(WasmType::I32);
-
-                operands[1].load(&mut self.instructions);
-                if size > 1 {
-                    self.instructions
-                        .push(wasm_encoder::Instruction::I32Const(size as i32));
-                    self.instructions.push(wasm_encoder::Instruction::I32Mul);
-                }
-
-                self.instructions
-                    .push(wasm_encoder::Instruction::I32Const(alignment as i32));
-                self.instructions
-                    .push(wasm_encoder::Instruction::Call(self.parent_realloc_index));
-                // TODO: trap on alloc failure
-                self.instructions
-                    .push(wasm_encoder::Instruction::LocalTee(ptr));
-                operands[0].load(&mut self.instructions);
-                operands[1].load(&mut self.instructions);
-                self.instructions
-                    .push(wasm_encoder::Instruction::MemoryCopy {
-                        src: ADAPTED_MEMORY_INDEX,
-                        dst: PARENT_MEMORY_INDEX,
-                    });
+                let ptr =
+                    self.emit_copy_list(size, alignment, &operands[0], &operands[1], false, None);
 
                 results.push(Operand::List {
                     addr: ptr,
-                    len: operands[1]
-                        .local()
-                        .expect("expected a local for the length"),
+                    len: operands[1].local().unwrap(),
                 });
             }
-            Instruction::ListLift { .. } => unreachable!(),
-            Instruction::IterElem => todo!(),
-            Instruction::IterBasePointer => todo!(),
+            Instruction::ListLift { element, free } => {
+                // Lifting goes from adapted module to parent module
+                assert_eq!(*free, Some(FREE_EXPORT_NAME));
+
+                let offsets = offsets_for_type(interface, &self.sizes, element);
+                let size = self.sizes.size(element) as u32;
+                let alignment = self.sizes.align(element) as u32;
+
+                let ptr = self.emit_copy_list(
+                    size,
+                    alignment,
+                    &operands[0],
+                    &operands[1],
+                    false,
+                    Some(offsets),
+                );
+
+                results.push(Operand::List {
+                    addr: ptr,
+                    len: operands[1].local().unwrap(),
+                });
+            }
+            Instruction::IterElem => {
+                results.push(Operand::Global(ELEMENT_GLOBAL));
+            }
+            Instruction::IterBasePointer => {
+                results.push(Operand::GlobalPointer {
+                    addr: BASE_POINTER_GLOBAL,
+                    memory: 0, // Not important
+                });
+            }
             Instruction::BufferLowerPtrLen { .. } => todo!(),
             Instruction::BufferLowerHandle { .. } => todo!(),
             Instruction::BufferLiftPtrLen { .. } => todo!(),
             Instruction::BufferLiftHandle { .. } => todo!(),
-            Instruction::RecordLower { .. }
-            | Instruction::FlagsLower { .. }
-            | Instruction::FlagsLower64 { .. } => match operands.swap_remove(0) {
-                Operand::Record { fields } => {
-                    for f in fields {
-                        results.push(*f);
-                    }
-                }
-                _ => panic!("expected a record operand"),
-            },
+            Instruction::RecordLower { record, .. }
+            | Instruction::FlagsLower { record, .. }
+            | Instruction::FlagsLower64 { record, .. } => {
+                results.extend(operands.swap_remove(0).lower_record(&self.sizes, record));
+            }
             Instruction::RecordLift { .. }
             | Instruction::FlagsLift { .. }
             | Instruction::FlagsLift64 { .. } => {
@@ -594,16 +919,14 @@ impl<'a> Bindgen for CodeGenerator<'a> {
             } => {
                 assert_eq!(operands.len(), sig.params.len());
                 for operand in operands.iter() {
-                    operand.load(&mut self.instructions);
+                    operand.load(self);
                 }
-                self.instructions
-                    .push(wasm_encoder::Instruction::Call(self.func_index));
+                self.emit_instruction(wasm_encoder::Instruction::Call(self.func_index));
 
                 if sig.retptr.is_some() {
                     assert_eq!(sig.results.len(), 1);
                     let local = self.alloc_local(sig.results[0]);
-                    self.instructions
-                        .push(wasm_encoder::Instruction::LocalSet(local));
+                    self.emit_instruction(wasm_encoder::Instruction::LocalSet(local));
                     results.push(Operand::Pointer {
                         addr: local,
                         memory: ADAPTED_MEMORY_INDEX,
@@ -611,8 +934,7 @@ impl<'a> Bindgen for CodeGenerator<'a> {
                 } else {
                     for ty in sig.results.iter() {
                         let local = self.alloc_local(*ty);
-                        self.instructions
-                            .push(wasm_encoder::Instruction::LocalSet(local));
+                        self.emit_instruction(wasm_encoder::Instruction::LocalSet(local));
                         results.push(Operand::Local(local));
                     }
                 }
@@ -626,27 +948,39 @@ impl<'a> Bindgen for CodeGenerator<'a> {
                     let mut offset = 0;
                     let mut types = retptr.iter();
 
-                    for o in operands {
-                        o.store(
-                            self,
-                            &Operand::Pointer {
-                                addr: retptr_index,
-                                memory: PARENT_MEMORY_INDEX,
-                            },
-                            &mut types,
-                            &mut offset,
-                            8,
-                        );
+                    for o in std::mem::take(operands) {
+                        for local in o.locals() {
+                            let ty = self.local_type(local);
+                            assert_eq!(ty, *types.next().unwrap());
+
+                            self.emit_store_from_local(
+                                &Operand::Pointer {
+                                    addr: retptr_index,
+                                    memory: PARENT_MEMORY_INDEX,
+                                },
+                                offset,
+                                &Operand::Local(local),
+                                match ty {
+                                    WasmType::I32 => StoreType::I32,
+                                    WasmType::I64 => StoreType::I64,
+                                    WasmType::F32 => StoreType::F32,
+                                    WasmType::F64 => StoreType::F64,
+                                },
+                            );
+
+                            // The return space is in 8-byte elements
+                            offset += 8;
+                        }
                     }
 
                     assert!(types.next().is_none());
                 } else {
                     for operand in operands {
-                        operand.load(&mut self.instructions);
+                        operand.load(self);
                     }
                 }
 
-                self.instructions.push(wasm_encoder::Instruction::End);
+                self.emit_instruction(wasm_encoder::Instruction::End);
             }
             Instruction::Witx { .. } => unreachable!(),
         }
@@ -661,10 +995,14 @@ impl<'a> Bindgen for CodeGenerator<'a> {
     }
 
     fn push_block(&mut self) {
-        unreachable!("should not be called")
+        self.instructions.push(Vec::new());
     }
 
-    fn finish_block(&mut self, _operand: &mut Vec<Self::Operand>) {}
+    fn finish_block(&mut self, operands: &mut Vec<Self::Operand>) {
+        assert!(!self.instructions.is_empty());
+        self.blocks
+            .push((std::mem::take(operands), self.instructions.pop().unwrap()));
+    }
 
     fn sizes(&self) -> &SizeAlign {
         &self.sizes
@@ -690,12 +1028,13 @@ mod test {
             .find(|f| f.name == "test")
             .unwrap();
 
-        let mut generator = CodeGenerator::new(&interface, func, 0, 1, 2);
+        let import_signature = interface.wasm_signature(CallMode::WasmImport, func);
+        let export_signature = interface.wasm_signature(CallMode::WasmExport, func);
+
+        let mut generator = CodeGenerator::new(&interface, func, &import_signature, 0, 1, 2);
 
         interface.call(CallMode::WasmExport, func, &mut generator);
 
-        let import_signature = interface.wasm_signature(CallMode::WasmImport, func);
-        let export_signature = interface.wasm_signature(CallMode::WasmExport, func);
         let func = generator.into_function();
 
         let mut module = Module::new();

--- a/crates/wasmlink/src/linker.rs
+++ b/crates/wasmlink/src/linker.rs
@@ -224,7 +224,7 @@ impl<'a> LinkedModule<'a> {
 
             // Emit the segments populating the function table
             let mut segments = Vec::new();
-            for (func, _, _) in adapted.module.interface.as_ref().unwrap().iter() {
+            for (func, _) in adapted.module.interface.as_ref().unwrap().iter() {
                 let func_index = self.imports.len() as u32 + self.func_aliases.len() as u32;
                 self.func_aliases.push((child_index, func.name.as_ref()));
 


### PR DESCRIPTION
Support is now implemented for lists of any currently supported types (i.e.
everything but variants).

It also fixes a bug in marshaling of canonical lists that have an element
size greater than 1.

Tests were added for lists of some basic types.

Additionally, interface functions that don't need to be adapted are now
directly aliased rather than generating an adapter function that simply called
the original function.